### PR TITLE
added depends on workaround

### DIFF
--- a/terraform-modules/api-services/variables.tf
+++ b/terraform-modules/api-services/variables.tf
@@ -1,6 +1,10 @@
 
 # google project
 variable "project" {}
+
+#depends_on work around
+variable "depends_on" { default = [], type = "list" }
+
 #services to enalbe
 variable "services" {
  type = "list"

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -76,3 +76,5 @@ variable "node_pool_count" {
   default = "3"
   description = "The number of nodes deployed in a node pool"
 }
+#depends_on work around
+variable "depends_on" { default = [], type = "list" }


### PR DESCRIPTION
##### This is a work around so you can specify the api-services module to run before the k8s module. I have a brand new project with zero APIs enabled and need them all as prerequisites to my tf configs. 

#### dependency error:
```
* google_container_cluster.cluster: googleapi: Error 403: Kubernetes Engine API has not been used in project 291823010495 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/container.googleapis
.com/overview?project=291823010495 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured      
```

#### depends_on error:
```
./terraform.sh init                                                                                                                                                                                          
Initializing modules...                                                                                                                                                                                                                      
- module.enable-services                                                                                                                                                                                                                     
- module.my-k8s-cluster                                                                                                                                                                                                                      
                                                                                                                                                                                                                                             
Initializing the backend...                                                                                                                                                                                                                  
                                                                                                                                                                                                                                             
Error: module "my-k8s-cluster": "depends_on" is not a valid argument      
```

Work around reference: https://github.com/hashicorp/terraform/issues/10462#issuecomment-285733504

#### code trigging depends_on error
```
module "my-k8s-cluster" {
  # terraform-shared repo
  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s?ref=ms-dependson"
  depends_on = ["module.enable-services"]
}