### PR TITLE
Support multiple instances of services module with diff google providers

### DIFF
--- a/terraform-modules/api-services/README.md
+++ b/terraform-modules/api-services/README.md
@@ -3,14 +3,23 @@
 ## Default Behavior
 This will enable 41 apis by default if you would like specify apis you can do so by defining a variable like below
 
+## Google Provider
+In order to support applying multiple instances of this module to different Google projects all in the same terraform configuration, you MUST specify the google provider when you instantuate the module.  The google provider used by the module is "named" google.target - in order to ensure no conflict or assumption on the provider you desire to use.
+
 ### sample deploy variable
 ```
+provider "google" {
+   alias   = "my-project"
+   project = "broad-myproject-dev"
+   region  = "us-central1-a"
+}
+
 module "enable-services" {
 
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services?ref=ms-apiservices"
 
   providers {
-    google = "google-beta"
+    google.target = "google.my-project"
   }
   project = "broad-myproject-dev"
   services = [

--- a/terraform-modules/api-services/api-services.tf
+++ b/terraform-modules/api-services/api-services.tf
@@ -1,17 +1,17 @@
 # ServiceUsage API
 resource "google_project_service" "serviceusage" {
-  provider = "google"
+  provider = "google.target"
   project = "${var.project}"
   service = "serviceusage.googleapis.com"
 }
 # cloudresourcemanager API
 resource "google_project_service" "cloudresourcemanager" {
-  provider = "google"
+  provider = "google.target"
   project = "${var.project}"
   service = "cloudresourcemanager.googleapis.com"
 }
 resource "google_project_service" "required-services" {
-  provider = "google"
+  provider = "google.target"
   project = "${var.project}"
   count = "${length(var.services)}"
   service = "${element(var.services, count.index)}"

--- a/terraform-modules/api-services/provider.tf
+++ b/terraform-modules/api-services/provider.tf
@@ -1,0 +1,4 @@
+
+provider "google" {
+  alias = "target"
+}


### PR DESCRIPTION
This allows the api-services module to support both multiple instances of the module applied to different google projects (with possibly different credentials).  The side effect of having that capability,  is that you MUST provide the google provider.  I purposely defined the provider in the module as google.target to avoid possible confusion and to force it to be explicit.

I updated README to hopefully explain that and show the updated example.