### PR TITLE
Made default behavior to NOT disable API upon resource destroy

### DIFF
--- a/terraform-modules/api-services/README.md
+++ b/terraform-modules/api-services/README.md
@@ -1,10 +1,13 @@
 ## Module for enabling api servics on GCP
 
 ## Default Behavior
-This will enable 41 apis by default if you would like specify apis you can do so by defining a variable like below
+This will enable 41 apis by default if you would like specify apis you can do so by defining a variable like below.  Also the default is NOT to disable API on resource destory.  This can be overriden by setting the destroy variable to true.
 
 ## Google Provider
 In order to support applying multiple instances of this module to different Google projects all in the same terraform configuration, you MUST specify the google provider when you instantuate the module.  The google provider used by the module is "named" google.target - in order to ensure no conflict or assumption on the provider you desire to use.
+
+## Service list ordering
+Due to how the module is implemented - iterating through the list and creating a "instance" of the resource for each service - changing the order of the list will cause a lot of destroy/creation tasks - which may not be desireable.  So it is best to add at the end of your service list after the initial apply.
 
 ### sample deploy variable
 ```

--- a/terraform-modules/api-services/api-services.tf
+++ b/terraform-modules/api-services/api-services.tf
@@ -3,17 +3,20 @@ resource "google_project_service" "serviceusage" {
   provider = "google.target"
   project = "${var.project}"
   service = "serviceusage.googleapis.com"
+  disable_on_destroy = "${var.destroy}"
 }
 # cloudresourcemanager API
 resource "google_project_service" "cloudresourcemanager" {
   provider = "google.target"
   project = "${var.project}"
   service = "cloudresourcemanager.googleapis.com"
+  disable_on_destroy = "${var.destroy}"
 }
 resource "google_project_service" "required-services" {
   provider = "google.target"
   project = "${var.project}"
   count = "${length(var.services)}"
   service = "${element(var.services, count.index)}"
+  disable_on_destroy = "${var.destroy}"
   depends_on = ["google_project_service.cloudresourcemanager","google_project_service.serviceusage"]
 }

--- a/terraform-modules/api-services/variables.tf
+++ b/terraform-modules/api-services/variables.tf
@@ -2,6 +2,9 @@
 # google project
 variable "project" {}
 
+# destroy on disable
+variable "destroy" { default = "false" }
+
 #depends_on work around
 variable "depends_on" { default = [], type = "list" }
 


### PR DESCRIPTION
Using a variable you change this behavior.  I also updated README - warning you not to screw with the the order of your service list after first apply.  Otherwise you will get a lot of resource destroy/create due to re-ordering