### PR TITLE
Adding support for enable/disable of api-services module

### DIFF
--- a/terraform-modules/api-services/README.md
+++ b/terraform-modules/api-services/README.md
@@ -3,6 +3,8 @@
 ## Default Behavior
 This will enable 41 apis by default if you would like specify apis you can do so by defining a variable like below.  Also the default is NOT to disable API on resource destory.  This can be overriden by setting the destroy variable to true.
 
+If you would like to disable all the resources this module creates without needing to comment it out in your terraform config, you can set the enable_flag to 0
+
 ## Google Provider
 In order to support applying multiple instances of this module to different Google projects all in the same terraform configuration, you MUST specify the google provider when you instantuate the module.  The google provider used by the module is "named" google.target - in order to ensure no conflict or assumption on the provider you desire to use.
 

--- a/terraform-modules/api-services/api-services.tf
+++ b/terraform-modules/api-services/api-services.tf
@@ -1,5 +1,7 @@
+
 # ServiceUsage API
 resource "google_project_service" "serviceusage" {
+  count    = "${var.enable_flag}"
   provider = "google.target"
   project = "${var.project}"
   service = "serviceusage.googleapis.com"
@@ -7,6 +9,7 @@ resource "google_project_service" "serviceusage" {
 }
 # cloudresourcemanager API
 resource "google_project_service" "cloudresourcemanager" {
+  count    = "${var.enable_flag}"
   provider = "google.target"
   project = "${var.project}"
   service = "cloudresourcemanager.googleapis.com"
@@ -15,7 +18,7 @@ resource "google_project_service" "cloudresourcemanager" {
 resource "google_project_service" "required-services" {
   provider = "google.target"
   project = "${var.project}"
-  count = "${length(var.services)}"
+  count = "${var.enable_flag == "1"?length(var.services):0}"
   service = "${element(var.services, count.index)}"
   disable_on_destroy = "${var.destroy}"
   depends_on = ["google_project_service.cloudresourcemanager","google_project_service.serviceusage"]

--- a/terraform-modules/api-services/variables.tf
+++ b/terraform-modules/api-services/variables.tf
@@ -8,6 +8,11 @@ variable "destroy" { default = "false" }
 #depends_on work around
 variable "depends_on" { default = [], type = "list" }
 
+# enable/disable var
+variable "enable_flag" { 
+   default = "1" 
+}
+
 #services to enalbe
 variable "services" {
  type = "list"


### PR DESCRIPTION
modules do not support the count setting.  So if you want to have an ability to "disable" what the module does without needing to comment everything out - you do that by passing in a var that all resources that the module creates use for their count.

