### PR TITLE
Address issue with module not working on custom networks and other bugs

### DIFF
--- a/terraform-modules/docker-instance-data-disk/README.md
+++ b/terraform-modules/docker-instance-data-disk/README.md
@@ -17,18 +17,18 @@ instance_docker_disk_name: docker
 instance_data_disk_size: 50
 instance_data_disk_type: pd-sd
 instance_data_disk_name: data
-instance_network_name: app-services
 instance_scopes:
     "userinfo-email",
     "compute-ro",
     "storage-ro",
     "https://www.googleapis.com/auth/monitoring.write",
     "logging-write" 
-instance_subnetwork_name: The same as what instance_network_name is set to
 
 The following module variables have an empty string/list/map as default:
 
+instance_subnetwork_name: 
 instance_tags
 instance_labels
 instance_service_account
 
+NOTE: instance_subnetwork_name is required and applying the plan will fail even though creating the plan will succeed.

--- a/terraform-modules/docker-instance-data-disk/README.md
+++ b/terraform-modules/docker-instance-data-disk/README.md
@@ -24,9 +24,11 @@ instance_scopes:
     "storage-ro",
     "https://www.googleapis.com/auth/monitoring.write",
     "logging-write" 
+instance_subnetwork_name: The same as what instance_network_name is set to
 
 The following module variables have an empty string/list/map as default:
 
 instance_tags
 instance_labels
 instance_service_account
+

--- a/terraform-modules/docker-instance-data-disk/instance-group.tf
+++ b/terraform-modules/docker-instance-data-disk/instance-group.tf
@@ -16,5 +16,8 @@ resource "google_compute_instance_group" "instance-group-unmanaged" {
     port = "443"
   }
 
-  zone = "${var.instance_zone}"
+ # zone = "${var.instance_zone}"
+  zone = "${element(google_compute_instance.instance.*.zone,0)}"
+  network = "${element(google_compute_instance.instance.*.network_interface.0.network,0)}"
+  depends_on = [ "google_compute_instance.instance" ]
 }

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -62,6 +62,7 @@ resource "google_compute_instance" "instance" {
 
   network_interface {
     network = "${var.instance_network_name}"
+    subnetwork = "${var.instance_subnetwork_name}"
     access_config {
       nat_ip = "${element(google_compute_address.instance-public-ip.*.address, count.index)}"
     }

--- a/terraform-modules/docker-instance-data-disk/variables.tf
+++ b/terraform-modules/docker-instance-data-disk/variables.tf
@@ -64,8 +64,13 @@ variable "instance_docker_disk_name" {
 }
 
 variable "instance_network_name" {
-  default = "app-services"
+  default = ""
   description = "The default network name to create instance"
+}
+
+variable "instance_subnetwork_name" {
+  default = ""
+  description = "The default subnetwork name to create instance"
 }
 
 variable "instance_scopes" {

--- a/terraform-modules/docker-instance/README.md
+++ b/terraform-modules/docker-instance/README.md
@@ -12,7 +12,6 @@ instance_image: centos-7
 instance_docker_disk_size: 50
 instance_docker_disk_type: pd-ssd
 instance_docker_disk_name: docker
-instance_network_name: app-services
 instance_scopes:
     "userinfo-email",
     "compute-ro",
@@ -20,10 +19,12 @@ instance_scopes:
     "https://www.googleapis.com/auth/monitoring.write",
     "logging-write" 
 instance_stop_for_update: true
-instance_subnetwork_name: The same as what instance_network_name is set to
 
 The following module variables have an empty string/list/map as default:
 
+instance_subnetwork_name:
 instance_tags
 instance_labels
 instance_service_account
+
+NOTE: instance_subnetwork_name is required and applying the plan will fail even though creating the plan will succeed.

--- a/terraform-modules/docker-instance/README.md
+++ b/terraform-modules/docker-instance/README.md
@@ -20,6 +20,7 @@ instance_scopes:
     "https://www.googleapis.com/auth/monitoring.write",
     "logging-write" 
 instance_stop_for_update: true
+instance_subnetwork_name: The same as what instance_network_name is set to
 
 The following module variables have an empty string/list/map as default:
 

--- a/terraform-modules/docker-instance/instance-group.tf
+++ b/terraform-modules/docker-instance/instance-group.tf
@@ -16,5 +16,8 @@ resource "google_compute_instance_group" "instance-group-unmanaged" {
     port = "443"
   }
 
-  zone = "${var.instance_zone}"
+  # zone = "${var.instance_zone}"
+  zone = "${element(google_compute_instance.instance.*.zone,0)}"
+  network = "${element(google_compute_instance.instance.*.network_interface.0.network,0)}"
+  depends_on = [ "google_compute_instance.instance" ]
 }

--- a/terraform-modules/docker-instance/instance.tf
+++ b/terraform-modules/docker-instance/instance.tf
@@ -55,7 +55,8 @@ resource "google_compute_instance" "instance" {
   allow_stopping_for_update = "${var.instance_stop_for_update}"
 
   network_interface {
-    network = "${var.instance_network_name}"
+    network    = "${var.instance_network_name}"
+    subnetwork = "${var.instance_subnetwork_name}"
     access_config {
       nat_ip = "${element(google_compute_address.instance-public-ip.*.address, count.index)}"
     }

--- a/terraform-modules/docker-instance/variables.tf
+++ b/terraform-modules/docker-instance/variables.tf
@@ -64,8 +64,13 @@ variable "instance_docker_disk_name" {
 }
 
 variable "instance_network_name" {
-  default = "app-services"
+  default = ""
   description = "The default network name to create instance"
+}
+
+variable "instance_subnetwork_name" {
+  default = ""
+  description = "The default subnetwork name to create instance"
 }
 
 variable "instance_scopes" {


### PR DESCRIPTION
Custom networks require that you specify the subnetwork_name when creating instances.  Networks created using the auto-subnet true, supports just specifying the network_name or subnetwork_name or both.  In order to work for both, the module was updated to require just subnetwork_name.  I left in support to specify the network_name in order to not break current use case.

In my testing I noticed times when the instance_group was not updated after tainting and rebuilding instances - I think adding the dependency to the instance_group resource should resolve this.

Additionally, the zone was hard coded and the network was left unspecified in instance_group.  This caused issues when rebuilding instances to a different network and zone.  THe instance group would not get updated and fail.  The change ties the instance group to the values from the instances for network name and zone.

