### PR TITLE
BigQuery sink permissions to write tables

### DIFF
--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -30,7 +30,7 @@ resource "google_logging_project_sink" "bigquery-log-sink" {
 # grant writer access to bigquery.
 resource "google_project_iam_binding" "bigquery-log-writer" {
     count =  "${var.enable_bigquery}"
-    role   = "roles/bigquery.dataEditor"
+    role   = "roles/bigquery.dataOwner"
     members = ["${google_logging_project_sink.bigquery-log-sink.writer_identity}"]
 }
 

--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -27,6 +27,14 @@ resource "google_logging_project_sink" "bigquery-log-sink" {
   unique_writer_identity = true
 }
 
+# grant writer access to bigquery.
+resource "google_project_iam_binding" "bigquery-log-writer" {
+    count =  "${var.enable_bigquery}"
+    role   = "roles/bigquery.dataEditor"
+    members ="${google_logging_project_sink.bigquery-log-sink.writer_identity}"
+}
+
+
 resource "google_storage_bucket" "logs" {
   count =  "${var.enable_gcs}"
   name     = "${var.project}_${var.application_name}_${var.owner}_audit${var.nonce != "" ? "_${var.nonce}" : ""}"

--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -31,7 +31,7 @@ resource "google_logging_project_sink" "bigquery-log-sink" {
 resource "google_project_iam_binding" "bigquery-log-writer" {
     count =  "${var.enable_bigquery}"
     role   = "roles/bigquery.dataEditor"
-    members ="${google_logging_project_sink.bigquery-log-sink.writer_identity}"
+    members = ["${google_logging_project_sink.bigquery-log-sink.writer_identity}"]
 }
 
 

--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -30,7 +30,7 @@ resource "google_logging_project_sink" "bigquery-log-sink" {
 # grant writer access to bigquery.
 resource "google_project_iam_binding" "bigquery-log-writer" {
     count =  "${var.enable_bigquery}"
-    role   = "roles/bigquery.dataOwner"
+    role   = "roles/bigquery.dataEditor"
     members = ["${google_logging_project_sink.bigquery-log-sink.writer_identity}"]
 }
 


### PR DESCRIPTION
[For BigQuery destinations, add the sink's writer identity to your dataset and give it the BigQuery Data Editor role.](https://cloud.google.com/logging/docs/export/configure_export_v2)