### PR TITLE
supply SSL policy to LB rather than creating it

### DIFF
--- a/terraform-modules/load-balanced-instances/service.tf
+++ b/terraform-modules/load-balanced-instances/service.tf
@@ -62,7 +62,8 @@ module "load-balancer" {
   }
   project       = "${var.instance_project}"
   load_balancer_name = "${var.owner}-${var.service}"
-  ssl_policy_name = "${var.owner}-${var.service}-ssl-policy"
+  ssl_policy_name = "${var.ssl_policy_name}"
+  load_balancer_ssl_policy_create = false
   load_balancer_ssl_certificates = [
     "${data.google_compute_ssl_certificate.terra-env-wildcard-ssl-certificate-red.name}",
     "${data.google_compute_ssl_certificate.terra-env-wildcard-ssl-certificate-black.name}"

--- a/terraform-modules/load-balanced-instances/variables.tf
+++ b/terraform-modules/load-balanced-instances/variables.tf
@@ -18,13 +18,12 @@ variable "service" {
 # Dependency Profiles' Vars
 #
 # DNS
-variable "dns_project" {
-}
+variable "dns_project" {}
+
 # SSL
-variable "google_compute_ssl_certificate_red" {
-}
-variable "google_compute_ssl_certificate_black" {
-}
+variable "ssl_policy_name" {}
+variable "google_compute_ssl_certificate_red" {}
+variable "google_compute_ssl_certificate_black" {}
 data "google_compute_ssl_certificate" "terra-env-wildcard-ssl-certificate-red" {
   name = "${var.google_compute_ssl_certificate_red}"
 }


### PR DESCRIPTION
When deleting the `http-load-balancer` module, we consistently  see the error:

```
Error: Error applying plan:                                                                                                          
                                                                                                                                                                                                                                                                                     
1 error(s) occurred:                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                     
* module.load-balanced-instances.module.load-balancer.google_compute_ssl_policy.tls12-ssl-policy (destroy): 1 error(s) occurred:                                                                                                                                                     
                                                                                                                                                                                                                                                                                     
* google_compute_ssl_policy.tls12-ssl-policy: Error reading SslPolicy: googleapi: Error 400: The ssl_policy resource 'projects/broad-wb-rluckom/global/sslPolicies/tls12-ssl-policy' is already being used by 'projects/broad-wb-rluckom/global/targetHttpsProxies/broad-wb-rluckom-th
urloe-load-balancer-100', resourceInUseByAnotherResource 
```

The reason we get this is that the [SSL policy in the load balancer](https://github.com/broadinstitute/terraform-shared/blob/master/terraform-modules/http-load-balancer/load-balancer.tf#L46) is specified as a _variable_ expression rather than the name of the [policy resource](https://github.com/broadinstitute/terraform-shared/blob/master/terraform-modules/http-load-balancer/ssl-policies.tf#L1). This in turn is because the module allows selectively disabling SSL policy creation, so linking the load balancer SSL policy to the ssl policy resource created by the module is not valid when there was no SSL policy created.

The ordinary way to handle hidden dependencies is with the [depends_on](https://www.terraform.io/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) lifecycle parameter in the terraform definition. In this case, we would need to specify a condition like "if we created an SSL policy, then the load balancer depends on it, but if we didn't then it doesn't". 

However, the `depends_on` docs state:

Arbitrary expressions are not allowed in the depends_on argument value, because its value must be known before Terraform knows resource relationships and thus before it can safely evaluate expressions.

So we are not able to establish that dependency correctly in the `http-load-balancer` module. What this means is that the first attempt to destroy the `http-load-balancer` module will _always fail_ in cases where the module has created its own SSL policy. In such cases, the destroy command will succeed the second time it is run.

This PR avoids that problem in one common case by making the `load-balanced-instances` module require an externally-created SSL policy.
 