### PR TITLE
Parameterize ansible branch to enable testing changes

### DIFF
--- a/terraform-modules/load-balanced-instances/service.tf
+++ b/terraform-modules/load-balanced-instances/service.tf
@@ -18,7 +18,7 @@ module "instances" {
   instance_labels = {
     "app" = "${var.service}",
     "owner" = "${var.owner}",
-    "ansible_branch" = "master",
+    "ansible_branch" = "${var.ansible_branch}",
     "ansible_project" = "terra-env",
   }
   instance_tags = "${var.instance_tags}"

--- a/terraform-modules/load-balanced-instances/variables.tf
+++ b/terraform-modules/load-balanced-instances/variables.tf
@@ -61,6 +61,11 @@ variable "instance_size" {
   description = "The default size of Service service hosts"
 }
 
+variable "ansible_branch" {
+  description = "The branch of dsp-ansible-configs to use when provisioning"
+  default = "master"
+}
+
 #
 # Service Service Config Bucket
 #


### PR DESCRIPTION
When the `load-balanced-instances` module was created, the `ansible_branch` label got hard-coded to master. In order to test Ansible changes, I added a variable that defaults to `master` for this module.