### PR TITLE
Upgrade k8s module to Terraform 0.12.

### DIFF
--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -16,8 +16,7 @@ resource "google_container_cluster" "cluster" {
   # CIS compliance: stackdriver monitoring
   monitoring_service = "monitoring.googleapis.com"
 
-  # Defines the minimum version allowed for the K8s master
-  min_master_version = var.master_version
+  min_master_version = var.k8s_version
 
   lifecycle {
     ignore_changes = [

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -3,7 +3,7 @@
 */
 
 resource "google_container_cluster" "cluster" {
-  provider = google
+  provider = google-beta
   name     = var.cluster_name
   zone     = var.zone
 
@@ -56,20 +56,7 @@ resource "google_container_cluster" "cluster" {
   # CIS compliance: Enable Alias IP Ranges. According to the terrafform
   # docs, setting these values blank gets default-size ranges automatically
   # chosen: https://www.terraform.io/docs/providers/google/r/container_cluster.html#ip_allocation_policy
-  dynamic "ip_allocation_policy" {
-    for_each = [var.ip_allocation_policy]
-    iterator = "policy"
-    content {
-      cluster_ipv4_cidr_block = policy.cluster_ipv4_cidr_block
-      cluster_secondary_range_name = policy.cluster_secondary_range_name
-      create_subnetwork = policy.create_subnetwork
-      node_ipv4_cidr_block = policy.node_ipv4_cidr_block
-      services_ipv4_cidr_block = policy.services_ipv4_cidr_block
-      services_secondary_range_name = policy.services_secondary_range_name
-      subnetwork_name = policy.subnetwork_name
-      use_ip_aliases = policy.use_ip_aliases
-    }
-  }
+  ip_allocation_policy = var.ip_allocation_policy
 
   # CIS compliance: Enable PodSecurityPolicyController
   pod_security_policy_config {
@@ -77,19 +64,15 @@ resource "google_container_cluster" "cluster" {
   }
 
   # OMISSION: CIS compliance: Enable Private Cluster
-  dynamic "private_cluster_config" {
-    for_each = [var.private_cluster_config]
-    iterator = "config"
-    content {
-      enable_private_endpoint = config.enable_private_endpoint
-      enable_private_nodes = config.enable_private_nodes
-      master_ipv4_cidr_block = config.master_ipv4_cidr_block
-    }
+  private_cluster_config {
+    enable_private_endpoint = var.enable_private_endpoint
+    enable_private_nodes = var.enable_private_nodes
+    master_ipv4_cidr_block = var.private_master_ipv4_cidr_block
   }
 
   master_authorized_networks_config {
     dynamic "cidr_blocks" {
-      for_each = [var.master_authorized_network_cidrs]
+      for_each = var.master_authorized_network_cidrs
       content {
         cidr_block = cidr_blocks.value
       }

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -19,9 +19,6 @@ resource "google_container_cluster" "cluster" {
   # Defines the minimum version allowed for the K8s master
   min_master_version = var.master_version
 
-  # CIS compliance: disable legacy Auth
-  enable_legacy_abac = false
-
   lifecycle {
     ignore_changes = [
       node_pool,
@@ -33,9 +30,11 @@ resource "google_container_cluster" "cluster" {
 
   # Silly, but necessary to have a default pool of 0 nodes. This allows the node definition to be handled cleanly
   # in a separate file
-  node_pool {
-    name = "default-pool"
-  }
+  remove_default_node_pool = true
+  initial_node_count = 0
+
+  # CIS compliance: disable legacy Auth
+  enable_legacy_abac = false
 
   # CIS compliance: disable basic auth -- this creates a certificate and
   # disables basic auth by not specifying a user / pasword.
@@ -89,12 +88,4 @@ resource "google_container_cluster" "cluster" {
       disabled = false
     }
   }
-}
-
-output "cluster_name" {
-  value = google_container_cluster.cluster.name
-}
-
-output "cluster_endpoint" {
-  value = google_container_cluster.cluster.endpoint
 }

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -3,41 +3,38 @@
 */
 
 resource "google_container_cluster" "cluster" {
-  provider            = "google"
-  name                = "${var.cluster_name}"
-  zone                = "${var.zone}"
+  provider = google
+  name     = var.cluster_name
+  zone     = var.zone
 
-  network             = "${var.cluster_network}"
-  subnetwork          = "${var.cluster_subnetwork}"
+  network    = var.cluster_network
+  subnetwork = var.cluster_subnetwork
 
   # CIS compliance: stackdriver logging
-  logging_service     = "logging.googleapis.com"
+  logging_service = "logging.googleapis.com"
+
   # CIS compliance: stackdriver monitoring
-  monitoring_service  = "monitoring.googleapis.com"
+  monitoring_service = "monitoring.googleapis.com"
 
   # Defines the minimum version allowed for the K8s master
-  min_master_version  = "${var.master_version}"
+  min_master_version = var.master_version
 
   # CIS compliance: disable legacy Auth
-  enable_legacy_abac  = "false"
+  enable_legacy_abac = false
 
   lifecycle {
-    ignore_changes  = [
-      "node_pool",
-      # this kept triggering a rebuild. No idea why
-      "master_auth.0.client_certificate_config.0.issue_client_certificate",
-
-      # It tries to update these to the specific format it likes even when the existing
-      # id is equivalent.
-      "network",
-      "subnetwork"
+    ignore_changes = [
+      node_pool,
+      master_auth[0].client_certificate_config[0].issue_client_certificate,
+      network,
+      subnetwork,
     ]
   }
 
   # Silly, but necessary to have a default pool of 0 nodes. This allows the node definition to be handled cleanly
   # in a separate file
   node_pool {
-    name            = "default-pool"
+    name = "default-pool"
   }
 
   # CIS compliance: disable basic auth -- this creates a certificate and
@@ -45,7 +42,7 @@ resource "google_container_cluster" "cluster" {
   # See https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth
   master_auth {
     client_certificate_config {
-      issue_client_certificate = "true"
+      issue_client_certificate = true
     }
     username = ""
     password = ""
@@ -59,24 +56,50 @@ resource "google_container_cluster" "cluster" {
   # CIS compliance: Enable Alias IP Ranges. According to the terrafform
   # docs, setting these values blank gets default-size ranges automatically
   # chosen: https://www.terraform.io/docs/providers/google/r/container_cluster.html#ip_allocation_policy
-  ip_allocation_policy = ["${var.ip_allocation_policy}"]
+  dynamic "ip_allocation_policy" {
+    for_each = [var.ip_allocation_policy]
+    iterator = "policy"
+    content {
+      cluster_ipv4_cidr_block = policy.cluster_ipv4_cidr_block
+      cluster_secondary_range_name = policy.cluster_secondary_range_name
+      create_subnetwork = policy.create_subnetwork
+      node_ipv4_cidr_block = policy.node_ipv4_cidr_block
+      services_ipv4_cidr_block = policy.services_ipv4_cidr_block
+      services_secondary_range_name = policy.services_secondary_range_name
+      subnetwork_name = policy.subnetwork_name
+      use_ip_aliases = policy.use_ip_aliases
+    }
+  }
 
   # CIS compliance: Enable PodSecurityPolicyController
   pod_security_policy_config {
     enabled = true
   }
 
-  # OMISSION: CIS compliance: Enable Private Cluster 
-  private_cluster_config = ["${var.private_cluster_config}"]
+  # OMISSION: CIS compliance: Enable Private Cluster
+  dynamic "private_cluster_config" {
+    for_each = [var.private_cluster_config]
+    iterator = "config"
+    content {
+      enable_private_endpoint = config.enable_private_endpoint
+      enable_private_nodes = config.enable_private_nodes
+      master_ipv4_cidr_block = config.master_ipv4_cidr_block
+    }
+  }
 
   master_authorized_networks_config {
-    cidr_blocks = ["${var.master_authorized_network_cidrs}"]
+    dynamic "cidr_blocks" {
+      for_each = [var.master_authorized_network_cidrs]
+      content {
+        cidr_block = cidr_blocks.value
+      }
+    }
   }
 
   addons_config {
     kubernetes_dashboard {
       # CIS compliance: Disable dashboard
-      disabled    = "true"
+      disabled = true
     }
 
     network_policy_config {
@@ -86,9 +109,9 @@ resource "google_container_cluster" "cluster" {
 }
 
 output "cluster_name" {
-  value = "${google_container_cluster.cluster.name}"
+  value = google_container_cluster.cluster.name
 }
 
 output "cluster_endpoint" {
-  value = "${google_container_cluster.cluster.endpoint}"
+  value = google_container_cluster.cluster.endpoint
 }

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -3,9 +3,9 @@
 */
 
 resource "google_container_cluster" "cluster" {
-  provider = google-beta
   name     = var.cluster_name
   zone     = var.zone
+  depends_on = [var.dependencies]
 
   network    = var.cluster_network
   subnetwork = var.cluster_subnetwork

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -18,7 +18,7 @@ resource "google_container_node_pool" "node-pool" {
     auto_upgrade = true
   }
 
-  version = var.node_version
+  version = var.k8s_version
 
   node_config {
     # CIS compliance: COS image

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -27,16 +27,12 @@ resource "google_container_node_pool" "node-pool" {
     disk_size_gb    = var.node_pool_disk_size_gb
     service_account = var.node_service_account
 
-    metadata = {
-      google-compute-enable-virtio-rng = var.enable_node_rng
-      disable-legacy-endpoints         = true
-    }
-
     # Protect node metadata
     workload_metadata_config {
       node_metadata = var.workload_metadata_config_node_metadata
     }
 
+    metadata = var.node_metadata
     labels = var.node_labels
     tags   = var.node_tags
 

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -29,7 +29,7 @@ resource "google_container_node_pool" "node-pool" {
 
     metadata = {
       google-compute-enable-virtio-rng = var.enable_node_rng
-      disable-legacy-endpoints         = "true"
+      disable-legacy-endpoints         = true
     }
 
     # Protect node metadata

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -3,45 +3,44 @@
 */
 
 resource "google_container_node_pool" "node-pool" {
-  provider            = "google"
-  depends_on  = [
-    "google_container_cluster.cluster"
-  ]
-  name        = "${var.cluster_name}-np"
-  zone        = "${var.zone}"
-  cluster     = "${google_container_cluster.cluster.name}"
-  node_count  = "${var.node_pool_count}"
+  provider   = google
+  depends_on = [google_container_cluster.cluster]
+  name       = "${var.cluster_name}-np"
+  zone       = var.zone
+  cluster    = google_container_cluster.cluster.name
+  node_count = var.node_pool_count
 
   management {
     # CIS compliance: enable automatic repair
     auto_repair = true
+
     # CIS compliance: enable automatic upgrade
     auto_upgrade = true
   }
 
-  version = "${var.node_version}"
+  version = var.node_version
 
   node_config {
     # CIS compliance: COS image
     image_type      = "COS"
-    machine_type    = "${var.node_pool_machine_type}"
-    disk_size_gb    = "${var.node_pool_disk_size_gb}"
-    service_account = "${var.node_service_account}"
+    machine_type    = var.node_pool_machine_type
+    disk_size_gb    = var.node_pool_disk_size_gb
+    service_account = var.node_service_account
 
-    metadata {
-      google-compute-enable-virtio-rng = "${var.enable_node_rng}"
-      disable-legacy-endpoints = "true"
+    metadata = {
+      google-compute-enable-virtio-rng = var.enable_node_rng
+      disable-legacy-endpoints         = "true"
     }
 
     # Protect node metadata
     workload_metadata_config {
-      node_metadata = "${var.workload_metadata_config_node_metadata}"
+      node_metadata = var.workload_metadata_config_node_metadata
     }
 
-    labels = "${var.node_labels}"
-    tags = "${var.node_tags}"
+    labels = var.node_labels
+    tags   = var.node_tags
 
-    oauth_scopes    = [
+    oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
       "https://www.googleapis.com/auth/logging.write",

--- a/terraform-modules/k8s/outputs.tf
+++ b/terraform-modules/k8s/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_name" {
+  value = google_container_cluster.cluster.name
+}
+
+output "cluster_endpoint" {
+  value = google_container_cluster.cluster.endpoint
+}

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -81,18 +81,12 @@ variable "master_authorized_network_cidrs" {
   type = list(string)
 }
 
-variable "master_version" {
+variable "k8s_version" {
   type    = string
-  default = "1.12.5-gke.10"
+  description = "Version of k8s to use in the GKE master and nodes"
 }
 
 # Node Pool Variables
-variable "node_version" {
-  type        = string
-  default     = "1.12.5-gke.10"
-  description = "The version of the kubernetes software deployed on the kubernetes nodes"
-}
-
 variable "node_pool_machine_type" {
   type        = string
   default     = "n1-highmem-8"

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -20,6 +20,7 @@ variable "private_master_ipv4_cidr_block" {
 
 variable "node_service_account" {
   type    = string
+  default = null
 }
 
 variable "enable_node_rng" {

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -44,7 +44,7 @@ variable "ip_allocation_policy" {
     subnetwork_name = string,
     use_ip_aliases = bool
   }))
-  default = []
+  default = null
 }
 
 variable "node_tags" {
@@ -75,7 +75,7 @@ variable "master_ipv4_cidr_block" {
 }
 
 variable "master_authorized_network_cidrs" {
-  type = list(object({cidr_block = string}))
+  type = list(string)
 }
 
 variable "master_version" {

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -3,13 +3,19 @@ variable "zone" {
   default = "us-central1-a"
 }
 
-variable "private_cluster_config" {
-  type    = list(object({
-    enable_private_endpoint = bool,
-    enable_private_nodes = bool,
-    master_ipv4_cidr_block = string
-  }))
-  default = []
+variable "enable_private_endpoint" {
+  type = bool
+  default = null
+}
+
+variable "enable_private_nodes" {
+  type = bool
+  default = null
+}
+
+variable "private_master_ipv4_cidr_block" {
+  type = string
+  default = null
 }
 
 variable "node_service_account" {
@@ -68,7 +74,7 @@ variable "master_ipv4_cidr_block" {
 }
 
 variable "master_authorized_network_cidrs" {
-  type = list(string)
+  type = list(object({cidr_block = string}))
 }
 
 variable "master_version" {
@@ -99,4 +105,10 @@ variable "node_pool_count" {
   type        = number
   default     = 3
   description = "The number of nodes deployed in a node pool"
+}
+
+variable "dependencies" {
+  type = list(any)
+  default = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
 }

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -44,6 +44,9 @@ variable "ip_allocation_policy" {
     subnetwork_name = string,
     use_ip_aliases = bool
   }))
+  # IMPORTANT: This defaults to `null` instead of `[]`
+  # because `[]` overwrites the default argument of the
+  # underlying Google resource.
   default = null
 }
 
@@ -93,7 +96,6 @@ variable "node_version" {
 variable "node_pool_machine_type" {
   type        = string
   default     = "n1-highmem-8"
-  description = ""
 }
 
 variable "node_pool_disk_size_gb" {

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -1,80 +1,102 @@
 variable "zone" {
+  type    = string
   default = "us-central1-a"
 }
 
 variable "private_cluster_config" {
-  type = "list"
+  type    = list(object({
+    enable_private_endpoint = bool,
+    enable_private_nodes = bool,
+    master_ipv4_cidr_block = string
+  }))
   default = []
 }
 
 variable "node_service_account" {
-  default = ""
+  type    = string
 }
 
 variable "enable_node_rng" {
-  default =  false
+  type    = bool
+  default = false
 }
 
 variable "node_labels" {
-  type = "map"
+  type    = map(string)
   default = {}
 }
 
 variable "ip_allocation_policy" {
-  type = "list"
-  default = [
-    {
-      cluster_ipv4_cidr_block = ""
-      services_ipv4_cidr_block = ""
-    }
-  ]
+  type = list(object({
+    cluster_ipv4_cidr_block = string,
+    cluster_secondary_range_name = string,
+    create_subnetwork = bool,
+    node_ipv4_cidr_block = string,
+    services_ipv4_cidr_block = string,
+    services_secondary_range_name = string,
+    subnetwork_name = string,
+    use_ip_aliases = bool
+  }))
+  default = []
 }
 
 variable "node_tags" {
-  type = "list"
+  type    = list(string)
   default = []
 }
 
 variable "workload_metadata_config_node_metadata" {
+  type    = string
   default = "SECURE"
 }
 
 # Cluster Variables
-variable "cluster_name" {}
+variable "cluster_name" {
+  type = string
+}
 
-variable "cluster_network" {}
+variable "cluster_network" {
+  type = string
+}
 
-variable "cluster_subnetwork" {}
+variable "cluster_subnetwork" {
+  type = string
+}
 
-variable "master_ipv4_cidr_block" {}
+variable "master_ipv4_cidr_block" {
+  type = string
+}
 
 variable "master_authorized_network_cidrs" {
-  type = "list"
+  type = list(string)
 }
 
 variable "master_version" {
+  type    = string
   default = "1.12.5-gke.10"
 }
 
 # Node Pool Variables
 variable "node_version" {
-  default = "1.12.5-gke.10"
+  type        = string
+  default     = "1.12.5-gke.10"
   description = "The version of the kubernetes software deployed on the kubernetes nodes"
 }
 
 variable "node_pool_machine_type" {
-  default = "n1-highmem-8"
+  type        = string
+  default     = "n1-highmem-8"
   description = ""
 }
 
 variable "node_pool_disk_size_gb" {
-  default = "100"
+  type        = number
+  default     = 100
   description = "The size of the disk"
 }
 
 variable "node_pool_count" {
-  default = "3"
+  type        = number
+  default     = 3
   description = "The number of nodes deployed in a node pool"
 }
-#depends_on work around
-variable "depends_on" { default = [], type = "list" }

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -1,6 +1,39 @@
+# See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+variable "dependencies" {
+  type = any
+  default = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
+}
+
+# Cluster Variables
+variable "cluster_name" {
+  type = string
+}
+
 variable "zone" {
   type    = string
   default = "us-central1-a"
+}
+
+variable "k8s_version" {
+  type    = string
+  description = "Version of k8s to use in the GKE master and nodes"
+}
+
+variable "cluster_network" {
+  type = string
+}
+
+variable "cluster_subnetwork" {
+  type = string
+}
+
+variable "master_ipv4_cidr_block" {
+  type = string
+}
+
+variable "master_authorized_network_cidrs" {
+  type = list(string)
 }
 
 variable "enable_private_endpoint" {
@@ -16,21 +49,6 @@ variable "enable_private_nodes" {
 variable "private_master_ipv4_cidr_block" {
   type = string
   default = null
-}
-
-variable "node_service_account" {
-  type    = string
-  default = null
-}
-
-variable "enable_node_rng" {
-  type    = bool
-  default = false
-}
-
-variable "node_labels" {
-  type    = map(string)
-  default = {}
 }
 
 variable "ip_allocation_policy" {
@@ -50,43 +68,13 @@ variable "ip_allocation_policy" {
   default = null
 }
 
-variable "node_tags" {
-  type    = list(string)
-  default = []
-}
-
-variable "workload_metadata_config_node_metadata" {
-  type    = string
-  default = "SECURE"
-}
-
-# Cluster Variables
-variable "cluster_name" {
-  type = string
-}
-
-variable "cluster_network" {
-  type = string
-}
-
-variable "cluster_subnetwork" {
-  type = string
-}
-
-variable "master_ipv4_cidr_block" {
-  type = string
-}
-
-variable "master_authorized_network_cidrs" {
-  type = list(string)
-}
-
-variable "k8s_version" {
-  type    = string
-  description = "Version of k8s to use in the GKE master and nodes"
-}
-
 # Node Pool Variables
+variable "node_pool_count" {
+  type        = number
+  default     = 3
+  description = "The number of nodes deployed in a node pool"
+}
+
 variable "node_pool_machine_type" {
   type        = string
   default     = "n1-highmem-8"
@@ -98,14 +86,30 @@ variable "node_pool_disk_size_gb" {
   description = "The size of the disk"
 }
 
-variable "node_pool_count" {
-  type        = number
-  default     = 3
-  description = "The number of nodes deployed in a node pool"
+variable "node_service_account" {
+  type    = string
+  default = null
 }
 
-variable "dependencies" {
-  type = list(any)
+variable "workload_metadata_config_node_metadata" {
+  type    = string
+  default = "SECURE"
+}
+
+variable "node_metadata" {
+  type = map(string)
+  default = {
+    google-compute-enable-virtio-rng = false,
+    disable-legacy-endpoints = true
+  }
+}
+
+variable "node_labels" {
+  type    = map(string)
+  default = {}
+}
+
+variable "node_tags" {
+  type    = list(string)
   default = []
-  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
 }

--- a/terraform-modules/k8s/versions.tf
+++ b/terraform-modules/k8s/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Caveat: I have no idea what I'm doing ¯\\\_(ツ)\_/¯

I ran `terraform 0.12upgrade`, then updated the map / array access to use the new syntax. I still need to test actually running the new version, but `terraform init` doesn't spit out error any more.