### PR TITLE
Changed initial_node_count to 1

### DIFF
--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "cluster" {
   # Silly, but necessary to have a default pool of 0 nodes. This allows the node definition to be handled cleanly
   # in a separate file
   remove_default_node_pool = true
-  initial_node_count = 0
+  initial_node_count = 1 
 
   # CIS compliance: disable legacy Auth
   enable_legacy_abac = false


### PR DESCRIPTION
On clean deploy `initial_node_count = 0` will recieve the following error. 

```Error: googleapi: Error 400: Cluster.initial_node_count must be greater than zero., badRequest```