### PR TITLE
Fix 0.12 k8s module

### DIFF
--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -54,6 +54,16 @@ resource "google_container_cluster" "cluster" {
   ip_allocation_policy = [{
     # CIS compliance: Enable Alias IP Ranges.
     use_ip_aliases = true
+    # According to trial and error, setting these values to null
+    # lets Google derive values that actually work.
+    # Otherwise you'll end up flipping a table trying to set things manually.
+    create_subnetwork             = null
+    cluster_ipv4_cidr_block       = null
+    cluster_secondary_range_name  = null
+    node_ipv4_cidr_block          = null
+    services_ipv4_cidr_block      = null
+    services_secondary_range_name = null
+    subnetwork_name               = null
   }]
 
   # CIS compliance: Enable PodSecurityPolicyController

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "cluster" {
   # Silly, but necessary to have a default pool of 0 nodes. This allows the node definition to be handled cleanly
   # in a separate file
   remove_default_node_pool = true
-  initial_node_count = 1 
+  initial_node_count = 1
 
   # CIS compliance: disable legacy Auth
   enable_legacy_abac = false
@@ -51,10 +51,10 @@ resource "google_container_cluster" "cluster" {
     enabled = true
   }
 
-  # CIS compliance: Enable Alias IP Ranges. According to the terrafform
-  # docs, setting these values blank gets default-size ranges automatically
-  # chosen: https://www.terraform.io/docs/providers/google/r/container_cluster.html#ip_allocation_policy
-  ip_allocation_policy = var.ip_allocation_policy
+  ip_allocation_policy = [{
+    # CIS compliance: Enable Alias IP Ranges.
+    use_ip_aliases = true
+  }]
 
   # CIS compliance: Enable PodSecurityPolicyController
   pod_security_policy_config {

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -3,8 +3,8 @@
 */
 
 resource "google_container_cluster" "cluster" {
-  name     = var.cluster_name
-  zone     = var.zone
+  name       = var.cluster_name
+  location   = var.location
   depends_on = [var.dependencies]
 
   network    = var.cluster_network

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -6,7 +6,7 @@ resource "google_container_node_pool" "node-pool" {
   provider   = google
   depends_on = [google_container_cluster.cluster]
   name       = "${var.cluster_name}-np"
-  zone       = var.zone
+  location   = var.location
   cluster    = google_container_cluster.cluster.name
   node_count = var.node_pool_count
 

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -32,35 +32,18 @@ variable "master_authorized_network_cidrs" {
   type = list(string)
 }
 
-variable "enable_private_endpoint" {
-  type = bool
-  default = false
-}
-
-variable "enable_private_nodes" {
-  type = bool
-  default = false
-}
-
 variable "private_master_ipv4_cidr_block" {
   type = string
 }
 
-variable "ip_allocation_policy" {
-  type = list(object({
-    cluster_ipv4_cidr_block = string,
-    cluster_secondary_range_name = string,
-    create_subnetwork = bool,
-    node_ipv4_cidr_block = string,
-    services_ipv4_cidr_block = string,
-    services_secondary_range_name = string,
-    subnetwork_name = string,
-    use_ip_aliases = bool
-  }))
-  # IMPORTANT: This defaults to `null` instead of `[]`
-  # because `[]` overwrites the default argument of the
-  # underlying Google resource.
-  default = null
+variable "enable_private_nodes" {
+  type = bool
+  default = true
+}
+
+variable "enable_private_endpoint" {
+  type = bool
+  default = false
 }
 
 # Node Pool Variables

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "location" {
   type = string
   default = "us-central1-a"
-  description = "Zone or region to host the k8s master and node pool"
+  description = "Zone or region to host k8s. NOTE: passing a region here will give you a regional cluster with 3x the number of nodes."
 }
 
 variable "k8s_version" {

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -10,9 +10,10 @@ variable "cluster_name" {
   type = string
 }
 
-variable "zone" {
-  type    = string
-  default = "us-central1-a"
+variable "location" {
+  type = string
+  default = "us-central1"
+  description = "Zone or region to host the k8s master and node pool"
 }
 
 variable "k8s_version" {

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_name" {
 
 variable "location" {
   type = string
-  default = "us-central1"
+  default = "us-central1-a"
   description = "Zone or region to host the k8s master and node pool"
 }
 


### PR DESCRIPTION
For real this time. 

`ip_allocation_policy` is hard to get right, so we remove it as an input and hard-code values that make Google do the right thing.