### PR TITLE
Add toggle for new GKE logging / monitoring APIs.

### DIFF
--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -11,10 +11,10 @@ resource "google_container_cluster" "cluster" {
   subnetwork = var.cluster_subnetwork
 
   # CIS compliance: stackdriver logging
-  logging_service = "logging.googleapis.com"
+  logging_service = var.use_new_stackdriver_apis ? "logging.googleapis.com/kubernetes" : "logging.googleapis.com"
 
   # CIS compliance: stackdriver monitoring
-  monitoring_service = "monitoring.googleapis.com"
+  monitoring_service = var.use_new_stackdriver_apis ? "monitoring.googleapis.com/kubernetes" : "monitoring.googleapis.com"
 
   min_master_version = var.k8s_version
 

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -21,6 +21,12 @@ variable "k8s_version" {
   description = "Version of k8s to use in the GKE master and nodes"
 }
 
+variable "use_new_stackdriver_apis" {
+  type = bool
+  default = false
+  description = "If true, GKE's new APIs for logging / monitoring will be enabled. Otherwise legacy APIs will be used."
+}
+
 variable "cluster_network" {
   type = string
 }

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -23,7 +23,7 @@ variable "k8s_version" {
 
 variable "use_new_stackdriver_apis" {
   type = bool
-  default = false
+  default = true
   description = "If true, GKE's new APIs for logging / monitoring will be enabled. Otherwise legacy APIs will be used."
 }
 


### PR DESCRIPTION
I noticed this in my latest GKE cluster:
<img width="257" alt="Screen Shot 2019-09-05 at 9 10 55 AM" src="https://user-images.githubusercontent.com/2755881/64345420-54813300-cfbe-11e9-845c-276a0ccbc370.png">
Looks like Stackdriver has new GKE-specific monitoring support: https://cloud.google.com/monitoring/kubernetes-engine/. It's not GA for old k8s versions, so I left a toggle in just in case.

Relevant TF provider docs start here: https://www.terraform.io/docs/providers/google/r/container_cluster.html#logging_service