### PR TITLE
Add toggle for Workload Identity to k8s module

### DIFF
--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -71,6 +71,13 @@ resource "google_container_cluster" "cluster" {
     enabled = true
   }
 
+  dynamic "workload_identity_config" {
+    for_each = var.enable_workload_identity ? ["If only TF supported if/else"] : []
+    content {
+      identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+    }
+  }
+
   # OMISSION: CIS compliance: Enable Private Cluster
   private_cluster_config {
     enable_private_endpoint = var.enable_private_endpoint

--- a/terraform-modules/k8s/k8s-cluster.tf
+++ b/terraform-modules/k8s/k8s-cluster.tf
@@ -2,6 +2,9 @@
 * Kubernetes Cluster
 */
 
+# Needed for getting the ID of the project backing the k8s resource.
+data "google_project" "project" {}
+
 resource "google_container_cluster" "cluster" {
   name       = var.cluster_name
   location   = var.location

--- a/terraform-modules/k8s/k8s-node-pool.tf
+++ b/terraform-modules/k8s/k8s-node-pool.tf
@@ -29,7 +29,8 @@ resource "google_container_node_pool" "node-pool" {
 
     # Protect node metadata
     workload_metadata_config {
-      node_metadata = var.workload_metadata_config_node_metadata
+      # Workload Identity only works when using the metadata server.
+      node_metadata = var.enable_workload_identity ? "GKE_METADATA_SERVER" : "SECURE"
     }
 
     metadata = var.node_metadata

--- a/terraform-modules/k8s/variables.tf
+++ b/terraform-modules/k8s/variables.tf
@@ -27,6 +27,12 @@ variable "use_new_stackdriver_apis" {
   description = "If true, GKE's new APIs for logging / monitoring will be enabled. Otherwise legacy APIs will be used."
 }
 
+variable "enable_workload_identity" {
+  type = bool
+  default = false
+  description = "If true, enables k8s<->GCP SA linking in the cluster. See: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity"
+}
+
 variable "cluster_network" {
   type = string
 }
@@ -74,11 +80,6 @@ variable "node_pool_disk_size_gb" {
 variable "node_service_account" {
   type    = string
   default = null
-}
-
-variable "workload_metadata_config_node_metadata" {
-  type    = string
-  default = "SECURE"
 }
 
 variable "node_metadata" {


### PR DESCRIPTION
Workload Identity is Google's secret sauce for cross-linking k8s SAs and IAM SAs: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity. It'd help with my team's projects (so we don't have to grant the compute engine account permissions to everything).