### PR TITLE
Clean up TF 12 warnings in the api-services module.

### DIFF
--- a/terraform-modules/api-services/api-services.tf
+++ b/terraform-modules/api-services/api-services.tf
@@ -1,25 +1,29 @@
 
 # ServiceUsage API
-resource "google_project_service" "serviceusage" {
-  count    = "${var.enable_flag}"
-  provider = "google.target"
-  project = "${var.project}"
+resource google_project_service serviceusage {
+  count    = var.enable_flag ? 1 : 0
+  provider = google.target
+  project = var.project
   service = "serviceusage.googleapis.com"
-  disable_on_destroy = "${var.destroy}"
+  disable_on_destroy = var.destroy
 }
 # cloudresourcemanager API
-resource "google_project_service" "cloudresourcemanager" {
-  count    = "${var.enable_flag}"
-  provider = "google.target"
-  project = "${var.project}"
+resource google_project_service cloudresourcemanager {
+  count    = var.enable_flag ? 1 : 0
+  provider = google.target
+  project = var.project
   service = "cloudresourcemanager.googleapis.com"
-  disable_on_destroy = "${var.destroy}"
+  disable_on_destroy = var.destroy
+
 }
-resource "google_project_service" "required-services" {
-  provider = "google.target"
-  project = "${var.project}"
-  count = "${var.enable_flag == "1"?length(var.services):0}"
-  service = "${element(var.services, count.index)}"
-  disable_on_destroy = "${var.destroy}"
-  depends_on = ["google_project_service.cloudresourcemanager","google_project_service.serviceusage"]
+resource google_project_service required-services {
+  count = var.enable_flag ? length(var.services) : 0
+  provider = google.target
+  project = var.project
+  service = var.services[count.index]
+  disable_on_destroy = var.destroy
+  depends_on = [
+    google_project_service.cloudresourcemanager,
+    google_project_service.serviceusage
+  ]
 }

--- a/terraform-modules/api-services/variables.tf
+++ b/terraform-modules/api-services/variables.tf
@@ -1,18 +1,22 @@
 
 # google project
-variable "project" {}
+variable project {}
 
 # destroy on disable
-variable "destroy" { default = "false" }
+variable destroy {
+  type = bool
+  default = false
+}
 
 # enable/disable var
-variable "enable_flag" { 
-   default = "1" 
+variable enable_flag {
+  type = bool
+  default = true
 }
 
 #services to enalbe
-variable "services" {
- type = "list"
+variable services {
+ type = list(string)
  default = [
    "appengineflex.googleapis.com",
    "bigquery-json.googleapis.com",


### PR DESCRIPTION
The latest patch version of TF 12 is yelling at me, mainly about things that are quoted but shouldn't be. I noticed some weird old-style typing too.