### PR TITLE
Make IP nullable

### DIFF
--- a/terraform-modules/internal-load-balanced-instances/service.tf
+++ b/terraform-modules/internal-load-balanced-instances/service.tf
@@ -57,7 +57,7 @@ resource "google_storage_bucket_iam_member" "app_config" {
 #  must be created before load balancer
 #  Potential solution: https://github.com/hashicorp/terraform/issues/1178#issuecomment-207369534
 module "load-balancer" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/internal-load-balancer?ref=http-load-balancer-0.3.1-tf-0.12"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/internal-load-balancer?ref=http-load-balancer-0.3.2-tf-0.12"
 
   providers = {
     google.target =  "google.instances"

--- a/terraform-modules/internal-load-balancer/variables.tf
+++ b/terraform-modules/internal-load-balancer/variables.tf
@@ -22,7 +22,7 @@ variable "load_balancer_instance_groups" {
 
 variable "load_balancer_ip_address" {
   description = "private ip address to use for load balancer"
-  default = ""
+  default = null
 }
 
 variable "load_balancer_timeout" {


### PR DESCRIPTION
Fix for issue where the load-balancer-internal-lb-forwarding-rule in the internal-load-balancer module stopped accepting an empty string as a valid input for the ip_address field and requires it to be either null/absent or a valid IP.