### PR TITLE
Add option to disable authorized networks for the public master endpoint

### DIFF
--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -93,7 +93,7 @@ resource google_container_cluster cluster {
 
 
   dynamic "master_authorized_networks_config" {
-    for_each = var.enable_master_authorized_networks ? [1] : []
+    for_each = length(var.authorized_network_cidrs) == 0 ? [1] : []
     content {
       dynamic "cidr_blocks" {
         for_each = var.authorized_network_cidrs

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -93,7 +93,7 @@ resource google_container_cluster cluster {
 
 
   dynamic "master_authorized_networks_config" {
-    for_each = length(var.authorized_network_cidrs) == 0 ? [1] : []
+    for_each = length(var.authorized_network_cidrs) != 0 ? [1] : []
     content {
       dynamic "cidr_blocks" {
         for_each = var.authorized_network_cidrs

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -91,7 +91,9 @@ resource google_container_cluster cluster {
     master_ipv4_cidr_block = var.private_ipv4_cidr_block
   }
 
-  master_authorized_networks_config {
+
+  dynamic "master_authorized_networks_config" {
+    for_each = var.enable_master_authorized_networks ? [1] : []
     dynamic "cidr_blocks" {
       for_each = var.authorized_network_cidrs
       content {

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -94,10 +94,12 @@ resource google_container_cluster cluster {
 
   dynamic "master_authorized_networks_config" {
     for_each = var.enable_master_authorized_networks ? [1] : []
-    dynamic "cidr_blocks" {
-      for_each = var.authorized_network_cidrs
-      content {
-        cidr_block = cidr_blocks.value
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.authorized_network_cidrs
+        content {
+          cidr_block = cidr_blocks.value
+        }
       }
     }
   }

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -28,11 +28,6 @@ variable subnetwork {
   type = string
 }
 
-variable enable_master_authorized_networks {
-  type = bool
-  default = true
-}
-
 variable authorized_network_cidrs {
   type = list(string)
   default = []

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -28,6 +28,11 @@ variable subnetwork {
   type = string
 }
 
+variable enable_master_authorized_networks {
+  type = bool
+  default = true
+}
+
 variable authorized_network_cidrs {
   type = list(string)
 }

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -35,6 +35,7 @@ variable enable_master_authorized_networks {
 
 variable authorized_network_cidrs {
   type = list(string)
+  default = []
 }
 
 variable private_ipv4_cidr_block {


### PR DESCRIPTION
Default is still to enable them.
[See Slack thread](https://broadinstitute.slack.com/archives/CADU7L0SZ/p1580838106102200)