### PR TITLE
CA-679 Unpeg k8s-master and k8s-node-poll google provider version.

### DIFF
--- a/terraform-modules/k8s-master/versions.tf
+++ b/terraform-modules/k8s-master/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 3.2.0"
-    google-beta = "~> 3.2.0"
+    google = ">= 3.2.0"
+    google-beta = ">= 3.2.0"
   }
 }

--- a/terraform-modules/k8s-node-pool/versions.tf
+++ b/terraform-modules/k8s-node-pool/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 3.2.0"
-    google-beta = "~> 3.2.0"
+    google = ">= 3.2.0"
+    google-beta = ">= 3.2.0"
   }
 }


### PR DESCRIPTION
The pegged version is stopping terraform-ap-deployments from using any google provider version more recent that 3.2.0.

Pegging provider versions in shared modules makes it harder to re-use the modules for other deployments.