### PR TITLE
DR-895: Add missing nonce to dataset to match sink

### DIFF
--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -118,7 +118,7 @@ output "dataset_id" {
 }
 
 output "dataset_path" {
-  value = "bigquery.googleapis.com/projects/${var.project}/datasets/${replace(var.project, "-", "_")}_${var.application_name}_${var.owner}_audit"
+  value = "bigquery.googleapis.com/projects/${var.project}/datasets/${replace(var.project, "-", "_")}_${var.application_name}_${var.owner}_audit${var.nonce != "" ? "_${var.nonce}" : ""}"
 }
 
 output "log_filter" {


### PR DESCRIPTION
Sink includes nonce for dataset id so make sure BQ dataset also includes nonce.