### PR TITLE
Add count offset parameters for mongo and instance modules

### DIFF
--- a/terraform-modules/docker-instance-data-disk/instance-data-disk.tf
+++ b/terraform-modules/docker-instance-data-disk/instance-data-disk.tf
@@ -3,7 +3,7 @@ resource "google_compute_disk" "instance-data-disk" {
    provider = google.target
    project  = var.project
    count    = var.enable_flag == "1" ? var.instance_num_hosts : 0
-   name     = format("%s-%02d-data-disk", var.instance_name, count.index+1)
+   name     = format("%s-%02d-data-disk", var.instance_name, count.index + 1 + var.instance_count_offset)
    size     = var.instance_data_disk_size
    type     = var.instance_data_disk_type
    zone     = var.instance_zone

--- a/terraform-modules/docker-instance-data-disk/instance-group.tf
+++ b/terraform-modules/docker-instance-data-disk/instance-group.tf
@@ -6,7 +6,7 @@ resource "google_compute_instance_group" "instance-group-unmanaged" {
   provider = google.target
   project =  var.project
   count = var.enable_flag
-  name        = "${var.instance_name}-instance-group-unmanaged"
+  name        = var.instance_group_name == null ? "${var.instance_name}-instance-group-unmanaged" : var.instance_group_name
   description = "${var.instance_name} Instance Group - Unmanaged"
 
   instances = google_compute_instance.instance.*.self_link

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -7,7 +7,7 @@ resource "google_compute_address" "instance-public-ip" {
   provider = google.target
   project =  var.project
   count = var.enable_flag == "1" ? var.instance_num_hosts : 0
-  name = format("%s-%02d", var.instance_name, count.index+1)
+  name = format("%s-%02d", var.instance_name, count.index + 1 + var.instance_count_offset)
   region = var.instance_region
 }
 
@@ -16,7 +16,7 @@ resource "google_compute_disk" "instance-docker-disk" {
   provider = google.target
   project = var.project
   count = var.enable_flag == "1" ? var.instance_num_hosts : 0
-  name = format("%s-%02d-docker-disk", var.instance_name, count.index+1)
+  name = format("%s-%02d-docker-disk", var.instance_name, count.index + 1 + var.instance_count_offset)
   size = var.instance_docker_disk_size
   type = var.instance_docker_disk_type
   zone = var.instance_zone
@@ -31,8 +31,8 @@ data "google_compute_subnetwork" "instance-subnetwork" {
 resource "google_compute_instance" "instance" {
   provider = google.target
   project =  var.project
-  name = format("%s-%02d", var.instance_name, count.index+1)
-  count = var.enable_flag == "1"?var.instance_num_hosts:0
+  name = format("%s-%02d", var.instance_name, count.index + 1 + var.instance_count_offset)
+  count = var.enable_flag == "1" ? var.instance_num_hosts : 0
   machine_type = var.instance_size
   zone = var.instance_zone
   depends_on = [ google_compute_address.instance-public-ip, google_compute_disk.instance-docker-disk ]

--- a/terraform-modules/docker-instance-data-disk/variables.tf
+++ b/terraform-modules/docker-instance-data-disk/variables.tf
@@ -75,6 +75,11 @@ variable "instance_docker_disk_name" {
   description = "default disk type for docker volume"
 }
 
+variable "instance_group_name" {
+  default = null
+  description = "Name of instance group. Defaults to [instance name]-instance-group-unmanaged"
+}
+
 variable "instance_network_name" {
   default = ""
   description = "The default network name to create instance"

--- a/terraform-modules/docker-instance-data-disk/variables.tf
+++ b/terraform-modules/docker-instance-data-disk/variables.tf
@@ -39,6 +39,12 @@ variable "instance_num_hosts" {
   description = "default number of instances this module will create"
 }
 
+variable "instance_count_offset" {
+  default = 0
+  type    = number
+  description = "Offset at which to start naming suffix. If set to 1, first foo instance created will be foo-02"
+}
+
 variable "instance_root_disk_size" {
   default = "50"
   description = "default size of instance"

--- a/terraform-modules/mongodb/instances.tf
+++ b/terraform-modules/mongodb/instances.tf
@@ -12,6 +12,7 @@ module "instances" {
   instance_size = var.instance_size
   instance_image = var.instance_image
   instance_count_offset = var.instance_count_offset
+  instance_group_name = var.instance_group_name
   instance_data_disk_size = var.instance_data_disk_size
   instance_data_disk_type = var.instance_data_disk_type
   instance_data_disk_name = var.instance_data_disk_name

--- a/terraform-modules/mongodb/instances.tf
+++ b/terraform-modules/mongodb/instances.tf
@@ -1,7 +1,7 @@
 
 # Docker instance(s)
 module "instances" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance-data-disk?ref=docker-instance-data-disk-0.2.3-tf-0.12"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance-data-disk?ref=gm-count-offset"
 
   providers = {
     google.target = google.target
@@ -11,6 +11,7 @@ module "instances" {
   instance_num_hosts = length(var.mongodb_roles)
   instance_size = var.instance_size
   instance_image = var.instance_image
+  instance_count_offset = var.instance_count_offset
   instance_data_disk_size = var.instance_data_disk_size
   instance_data_disk_type = var.instance_data_disk_type
   instance_data_disk_name = var.instance_data_disk_name

--- a/terraform-modules/mongodb/instances.tf
+++ b/terraform-modules/mongodb/instances.tf
@@ -1,7 +1,7 @@
 
 # Docker instance(s)
 module "instances" {
-  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance-data-disk?ref=gm-count-offset"
+  source        = "github.com/broadinstitute/terraform-shared.git//terraform-modules/docker-instance-data-disk?ref=docker-instance-data-disk-0.2.4-tf-0.12"
 
   providers = {
     google.target = google.target

--- a/terraform-modules/mongodb/variables.tf
+++ b/terraform-modules/mongodb/variables.tf
@@ -42,6 +42,11 @@ variable "instance_zone" {
   description = "The zone where instances will be created"
 }
 
+variable "instance_group_name" {
+  default = null
+  description = "Name of instance group. Defaults to [instance name]-instance-group-unmanaged"
+}
+
 variable "instance_root_disk_size" {
   default = "50"
   description = "default size of instance"

--- a/terraform-modules/mongodb/variables.tf
+++ b/terraform-modules/mongodb/variables.tf
@@ -57,6 +57,12 @@ variable "instance_image" {
   description = "Image used to build instance"
 }
 
+variable "instance_count_offset" {
+  default = 0
+  type    = number
+  description = "Offset at which to start naming suffix. If set to 1, first foo instance created will be foo-02"
+}
+
 variable "instance_docker_disk_size" {
   default = "50"
   description = "default size of docker volume"


### PR DESCRIPTION
- Add optional count offset parameters for docker instance and mongo modules to enable avoiding name collisions
- Add optional instance group name parameter to docker instance module to enable avoiding name collisions