### PR TITLE
DDO-285 Fix an issue where TF explicitly tries to delete upgrade_settings

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -1,5 +1,5 @@
 resource google_container_node_pool pool {
-  provider   = google-beta
+  provider = google-beta
 
   depends_on = [var.dependencies]
   name       = var.name
@@ -13,6 +13,11 @@ resource google_container_node_pool pool {
 
     # CIS compliance: enable automatic upgrade
     auto_upgrade = true
+  }
+
+  upgrade_settings {
+    max_unavailable = var.upgrade_settings.max_unavailable
+    max_surge       = var.upgrade_settings.max_surge
   }
 
   node_config {
@@ -29,8 +34,8 @@ resource google_container_node_pool pool {
     }
 
     metadata = var.metadata
-    labels = var.labels
-    tags   = var.tags
+    labels   = var.labels
+    tags     = var.tags
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",

--- a/terraform-modules/k8s-node-pool/variables.tf
+++ b/terraform-modules/k8s-node-pool/variables.tf
@@ -1,27 +1,27 @@
 # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
 variable dependencies {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
 }
 
 variable name {
-  type = string
+  type        = string
   description = "Name to assign to the node pool."
 }
 
 variable master_name {
-  type = string
+  type        = string
   description = "Name of the GKE master / cluster where the node pool should be provisioned."
 }
 
 variable location {
-  type = string
+  type        = string
   description = "Location where the node pool should be provisioned."
 }
 
 variable node_count {
-  type = number
+  type        = number
   description = "Number of nodes to provision in the pool."
 }
 
@@ -30,19 +30,19 @@ variable machine_type {
 }
 
 variable disk_size_gb {
-  type = number
+  type        = number
   description = "Size of disk to allocate for each node in the pool."
 }
 
 variable service_account {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Email of the SA that should run workloads in each pool. The default compute account will be used if not set."
 }
 
 variable enable_workload_identity {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "If true, enables k8s<->GCP SA linking for workloads in the pool. See: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."
 }
 
@@ -50,16 +50,24 @@ variable metadata {
   type = map(string)
   default = {
     google-compute-enable-virtio-rng = false,
-    disable-legacy-endpoints = true
+    disable-legacy-endpoints         = true
   }
 }
 
 variable labels {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 
 variable tags {
-  type = list(string)
+  type    = list(string)
   default = []
+}
+
+variable upgrade_settings {
+  type = object({ max_surge = number, max_unavailable = number })
+  default = {
+    max_surge       = 1
+    max_unavailable = 0
+  }
 }

--- a/terraform-modules/k8s-node-pool/versions.tf
+++ b/terraform-modules/k8s-node-pool/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = ">= 3.2.0"
-    google-beta = ">= 3.2.0"
+    google      = ">= 3.14.0"
+    google-beta = ">= 3.14.0"
   }
 }

--- a/terraform-modules/stackdriver/k8s-cluster-monitoring/versions.tf
+++ b/terraform-modules/stackdriver/k8s-cluster-monitoring/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 3.2.0"
+    google = ">= 3.2.0"
   }
 }


### PR DESCRIPTION
In the terraform-ap-deployments repo, Terraform is attempting to delete the following setting on node pools:

      upgrade_settings {
          max_surge       = 1 -> null
          max_unavailable = 0 -> null
      }

and failing, because Google refuses to delete it.

This randomly started happening today with no TF code changes, after succeeding on Friday afternoon. I'm not sure if it's a new provider release or Google API shenanigans, but either way, explicitly setting upgrade_settings seems to fix it.