### PR TITLE
Remove app name filter

### DIFF
--- a/terraform-modules/stackdriver/gae-monitoring/gae-dos-intercepts.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-dos-intercepts.tf
@@ -1,5 +1,5 @@
 locals {
-  dos_intercept_metric             = "metric.type=\"appengine.googleapis.com/http/server/dos_intercept_count\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\""
+  dos_intercept_metric             = "metric.type=\"appengine.googleapis.com/http/server/dos_intercept_count\" resource.type=\"gae_app\""
   dos_intercept_threshold          = 0
   dos_intercept_threshold_duration = "60s"
 }

--- a/terraform-modules/stackdriver/gae-monitoring/gae-dos-intercepts.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-dos-intercepts.tf
@@ -5,8 +5,8 @@ locals {
 }
 
 resource google_monitoring_alert_policy gae-dos-intercept-alert {
-  provider = google.target
-
+  provider              = google.target
+  project               = var.gae_host_project
   display_name          = "${var.service_name}-dos-intercept-alert"
   combiner              = "OR"
   enabled               = true

--- a/terraform-modules/stackdriver/gae-monitoring/gae-quota-denials.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-quota-denials.tf
@@ -5,8 +5,8 @@ locals {
 }
 
 resource google_monitoring_alert_policy gae-quota-denial-alert {
-  provider = google.target
-
+  provider              = google.target
+  project               = var.gae_host_project
   display_name          = "${var.service_name}-quota-denial-alert"
   combiner              = "OR"
   enabled               = true

--- a/terraform-modules/stackdriver/gae-monitoring/gae-quota-denials.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-quota-denials.tf
@@ -1,5 +1,5 @@
 locals {
-  quota_denial_metric             = "metric.type=\"appengine.googleapis.com/http/server/quota_denial_count\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\""
+  quota_denial_metric             = "metric.type=\"appengine.googleapis.com/http/server/quota_denial_count\" resource.type=\"gae_app\""
   quota_denial_threshold          = 0
   quota_denial_threshold_duration = "300s"
 }

--- a/terraform-modules/stackdriver/gae-monitoring/gae-reponse-latency.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-reponse-latency.tf
@@ -1,6 +1,6 @@
 locals {
   #  Specific information to configure conditions needed to trigger alert
-  response_latency_metric             = "metric.type=\"appengine.googleapis.com/http/server/response_latencies\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\""
+  response_latency_metric             = "metric.type=\"appengine.googleapis.com/http/server/response_latencies\" resource.type=\"gae_app\""
   response_latency_threshold          = 1500 # measured in ms
   response_latency_threshold_duration = "300s"
 }

--- a/terraform-modules/stackdriver/gae-monitoring/gae-reponse-latency.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-reponse-latency.tf
@@ -6,8 +6,8 @@ locals {
 }
 
 resource google_monitoring_alert_policy gae-response-latency-alert {
-  provider = google.target
-
+  provider              = google.target
+  project               = var.gae_host_project
   display_name          = "${var.service_name}-response-latency-alert"
   combiner              = "OR"
   enabled               = true

--- a/terraform-modules/stackdriver/gae-monitoring/gae-resource-usage.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-resource-usage.tf
@@ -1,6 +1,6 @@
 locals {
-  cpu_usage_metric    = "metric.type=\"appengine.googleapis.com/system/cpu/usage\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\""
-  memory_usage_metric = "metric.type=\"appengine.googleapis.com/system/memory/usage\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\""
+  cpu_usage_metric    = "metric.type=\"appengine.googleapis.com/system/cpu/usage\" resource.type=\"gae_app\""
+  memory_usage_metric = "metric.type=\"appengine.googleapis.com/system/memory/usage\" resource.type=\"gae_app\""
   # Unit is megacycles
   cpu_usage_threshold = 10000
   # Unit is bytes 

--- a/terraform-modules/stackdriver/gae-monitoring/gae-resource-usage.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-resource-usage.tf
@@ -9,8 +9,8 @@ locals {
 }
 
 resource google_monitoring_alert_policy gae-resource-usage-alert {
-  provider = google.target
-
+  provider              = google.target
+  project               = var.gae_host_project
   display_name          = "${var.service_name}-resource-usage-alert"
   combiner              = "OR"
   enabled               = true

--- a/terraform-modules/stackdriver/gae-monitoring/gae-response-codes.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-response-codes.tf
@@ -1,5 +1,5 @@
 locals {
-  response_code_metric = "metric.type=\"appengine.googleapis.com/http/server/response_count\" resource.type=\"gae_app\" resource.label.\"module_id\"=\"${var.service_name}\" metric.label.\"response_code\">=\"500\""
+  response_code_metric = "metric.type=\"appengine.googleapis.com/http/server/response_count\" resource.type=\"gae_app\" metric.label.\"response_code\">=\"500\""
   # Trigger alert if there are any responses with code 5xx
   response_code_threshold          = 0
   response_code_threshold_duration = "60s"

--- a/terraform-modules/stackdriver/gae-monitoring/gae-response-codes.tf
+++ b/terraform-modules/stackdriver/gae-monitoring/gae-response-codes.tf
@@ -6,8 +6,8 @@ locals {
 }
 
 resource google_monitoring_alert_policy gae-response-code-alert {
-  provider = google.target
-
+  provider              = google.target
+  project               = var.gae_host_project
   display_name          = "${var.service_name}-response-code-alert"
   combiner              = "OR"
   enabled               = true


### PR DESCRIPTION
Since the gae apps are being deployed to their own gcp project, filtering by app name is no longer necessary