### PR TITLE
Hf postgres update

### DIFF
--- a/.github/workflows/TerraformTest-cloudsql-postgress.yml
+++ b/.github/workflows/TerraformTest-cloudsql-postgress.yml
@@ -1,0 +1,54 @@
+name: Terraform Test - Cloudsql Postgresql module
+
+env:
+  terraform_directory: "terraform-modules/cloudsql-postgres"
+  terraform_version: "0.12.25"
+
+on:
+  pull_request:
+    branches: 
+      - master
+    paths:
+      - terraform-modules/cloudsql-postgres/**
+    
+jobs:
+  terraform_test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Run Terraform fmt (kind of a linter)
+    - name: Terraform format check
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.terraform_version }}
+        tf_actions_subcommand: 'fmt'
+        tf_actions_fmt_write: false
+        tf_actions_comment: true
+        tf_actions_working_dir: ${{ env.terraform_directory }}/test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Run Terraform init 
+    - name: Terraform init
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.terraform_version }}
+        tf_actions_subcommand: 'init'
+        tf_actions_comment: true
+        tf_actions_working_dir: ${{ env.terraform_directory }}/test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Run Terraform validate 
+    - name: Terraform validate
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.terraform_version }}
+        tf_actions_subcommand: 'validate'
+        tf_actions_comment: true
+        tf_actions_working_dir: ${{ env.terraform_directory }}/test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -3,9 +3,9 @@
 #
 
 resource "random_id" "cloudsql_id" {
-  count = var.enable ? 1 : 0
+  count       = var.enable ? 1 : 0
 
-  byte_length   = 8
+  byte_length = 8
 
   keepers = var.cloudsql_keepers ? {
     database_version = var.cloudsql_version
@@ -15,40 +15,39 @@ resource "random_id" "cloudsql_id" {
 resource "google_sql_database_instance" "cloudsql_instance" {
   count = var.enable ? 1 : 0
 
-  provider              = google.target
-  project               = var.project
-  region                = var.cloudsql_region
-  database_version      = var.cloudsql_version
-  name                  = "${var.cloudsql_name}-${random_id.cloudsql_id[0].hex}"
-  depends_on            = [ random_id.cloudsql_id, var.dependencies, google_service_networking_connection.private_vpc_connection ]
+  provider         = google.target
+  region           = var.cloudsql_region
+  database_version = var.cloudsql_version
+  name             = "${var.cloudsql_name}-${random_id.cloudsql_id[0].hex}"
+  depends_on       = [ random_id.cloudsql_id, var.dependencies, google_service_networking_connection.private_vpc_connection ]
 
   settings {
 
     # POSTGRES CONFIG
-    availability_type   = var.postgres_availability_type
+    availability_type = var.postgres_availability_type
 
-    activation_policy   = var.cloudsql_activation_policy
-    disk_autoresize     = var.cloudsql_disk_autoresize
-    disk_type           = var.cloudsql_disk_type
-    replication_type    = var.cloudsql_replication_type
-    tier                = var.cloudsql_tier
+    activation_policy = var.cloudsql_activation_policy
+    disk_autoresize   = var.cloudsql_disk_autoresize
+    disk_type         = var.cloudsql_disk_type
+    replication_type  = var.cloudsql_replication_type
+    tier              = var.cloudsql_tier
 
     backup_configuration {
-      binary_log_enabled    = false
-      enabled               = true
-      start_time            = "06:00"
+      binary_log_enabled = false
+      enabled            = true
+      start_time         = "06:00"
     }
 
-#    maintenance_window {
-#        day             = "${var.cloudsql_maintenance_window_day}"
-#        hour            = "${var.cloudsql_maintenance_window_hour}"
-#        update_track    = "${var.cloudsql_maintenance_window_update_track}"
-#    }
+    #    maintenance_window {
+    #        day             = "${var.cloudsql_maintenance_window_day}"
+    #        hour            = "${var.cloudsql_maintenance_window_hour}"
+    #        update_track    = "${var.cloudsql_maintenance_window_update_track}"
+    #    }
 
     ip_configuration {
-      ipv4_enabled  = var.private_enable == true ? false : true
+      ipv4_enabled    = var.private_enable == true ? false : true
       private_network = var.private_enable == true ? local.private_network : null
-      require_ssl   = true
+      require_ssl     = true
       dynamic "authorized_networks" {
         for_each = var.cloudsql_authorized_networks
         content {

--- a/terraform-modules/cloudsql-postgres/databases.tf
+++ b/terraform-modules/cloudsql-postgres/databases.tf
@@ -1,8 +1,8 @@
 resource "google_sql_database" "app_database" {
   for_each = local.app_dbs
 
-  provider  = google.target
-  name      = each.value.db
-  instance  = google_sql_database_instance.cloudsql_instance[0].name
-  depends_on = [ google_sql_database_instance.cloudsql_instance ]
+  provider   = google.target
+  name       = each.value.db
+  instance   = google_sql_database_instance.cloudsql_instance[0].name
+  depends_on = [google_sql_database_instance.cloudsql_instance]
 }

--- a/terraform-modules/cloudsql-postgres/outputs.tf
+++ b/terraform-modules/cloudsql-postgres/outputs.tf
@@ -8,17 +8,21 @@ output "instance_name" {
   depends_on = [google_sql_database_instance.cloudsql_instance]
 }
 
+output "connection_name" {
+  value = var.enable ? google_sql_database_instance.cloudsql_instance[0].connection_name : null
+}
+
 output "root_user_password" {
-  value = var.enable ? random_id.root_user_password.*.hex : null
-  sensitive = true
+  value      = var.enable ? random_id.root_user_password.*.hex : null
+  sensitive  = true
   depends_on = [random_id.root_user_password]
 }
 
 output "app_db_creds" {
   value = var.enable ? {
-    for db in keys(google_sql_database.app_database):
+    for db in keys(google_sql_database.app_database) :
     db => {
-      db = google_sql_database.app_database[db].name
+      db       = google_sql_database.app_database[db].name
       username = google_sql_user.app_user[db].name
       password = google_sql_user.app_user[db].password
     }

--- a/terraform-modules/cloudsql-postgres/test/test.tf
+++ b/terraform-modules/cloudsql-postgres/test/test.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = "broad-gotc-dev"
+}
+
+module "test_postgres" {
+  source = "../"
+
+  providers = {
+    google              = google
+    google.dns_provider = google
+  }
+
+}

--- a/terraform-modules/cloudsql-postgres/users.tf
+++ b/terraform-modules/cloudsql-postgres/users.tf
@@ -6,23 +6,23 @@ resource "random_id" "root_user_password" {
 resource "google_sql_user" "root_user" {
   count = var.enable ? 1 : 0
 
-  provider  = google.target
-  instance  = google_sql_database_instance.cloudsql_instance[0].name
-  name      = "root"
-  password  = random_id.root_user_password[0].hex
-  depends_on = [ google_sql_database_instance.cloudsql_instance ]
+  provider   = google.target
+  instance   = google_sql_database_instance.cloudsql_instance[0].name
+  name       = "root"
+  password   = random_id.root_user_password[0].hex
+  depends_on = [google_sql_database_instance.cloudsql_instance]
 }
 
 resource "random_id" "app_user_password" {
-  for_each  = local.app_dbs
+  for_each    = local.app_dbs
   byte_length = 16
 }
 resource "google_sql_user" "app_user" {
-  for_each  = local.app_dbs
+  for_each = local.app_dbs
 
-  provider  = google.target
-  instance  = google_sql_database_instance.cloudsql_instance[0].name
-  name      = each.value.username
-  password  = random_id.app_user_password[each.key].hex
-  depends_on = [ google_sql_database_instance.cloudsql_instance ]
+  provider   = google.target
+  instance   = google_sql_database_instance.cloudsql_instance[0].name
+  name       = each.value.username
+  password   = random_id.app_user_password[each.key].hex
+  depends_on = [google_sql_database_instance.cloudsql_instance]
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -3,14 +3,15 @@
 #
 
 variable "project" {
-  type = string
+  type        = string
   description = "Google project"
+  default     = null
 }
 
 variable "enable" {
-  type = bool
+  type        = bool
   description = "Enable flag for this module. If set to false, no resources will be created."
-  default = true
+  default     = true
 }
 
 # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
@@ -25,20 +26,20 @@ variable dependencies {
 #
 
 variable "cloudsql_name" {
-  type = string
-  default = "cloudsql"
+  type        = string
+  default     = "cloudsql"
   description = "DNS CNAME record target hostname for default instance in an env. Should be set as a vault env override for each env."
 }
 
 variable "cloudsql_region" {
-  type = string
-  default = "us-central1"
+  type        = string
+  default     = "us-central1"
   description = "The region for CloudSQL instances. NOTE: For Gen 2 instance, use standard gcloud regions."
 }
 
 variable "cloudsql_version" {
-  type = string
-  default = "POSTGRES_9_6"
+  type        = string
+  default     = "POSTGRES_9_6"
   description = "The version to use for CloudSQL instances."
 }
 
@@ -49,38 +50,38 @@ variable "cloudsql_keepers" {
 }
 
 variable "cloudsql_require_ssl" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Determines if SSL is required for connections to CloudSQL instances."
 }
 
 variable "cloudsql_tier" {
-  type = string
-  default = "db-custom-16-32768" # match sam postgres in prod
+  type        = string
+  default     = "db-custom-16-32768" # match sam postgres in prod
   description = "The default tier (DB instance size) for CloudSQL instances"
 }
 
 variable "cloudsql_disk_autoresize" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Determines if the CloudSQL instances will increase their disk size automatically"
 }
 
 variable "cloudsql_disk_type" {
-  type = string
-  default = "PD_SSD"
+  type        = string
+  default     = "PD_SSD"
   description = "The default disk type for CloudSQL instances"
 }
 
 variable "cloudsql_activation_policy" {
-  type = string
-  default = "ALWAYS"
+  type        = string
+  default     = "ALWAYS"
   description = "The default activation policy for CloudSQL instances"
 }
 
 variable "cloudsql_replication_type" {
-  type = string
-  default = "SYNCHRONOUS"
+  type        = string
+  default     = "SYNCHRONOUS"
   description = "The default replication type for CloudSQL instances"
 }
 
@@ -113,12 +114,12 @@ variable "postgres_availability_type" {
 variable "app_dbs" {
   description = "List of db name and username pairs"
   type = map(object({
-    db = string
+    db       = string
     username = string
   }))
   default = {
     default = {
-      db = "appdb"
+      db       = "appdb"
       username = "appuser"
     }
   }
@@ -128,15 +129,15 @@ locals {
 }
 
 variable "cloudsql_instance_labels" {
-  type = map
+  type        = map
   description = "CloudSQL instance labels"
-  default = {}
+  default     = {}
 }
 
 variable "cloudsql_authorized_networks" {
-  type = list(string)
+  type        = list(string)
   description = "CloudSQL authorized  networks"
-  default = []
+  default     = []
 }
 
 # private sql vars


### PR DESCRIPTION
Removed project as a required input.  Now project is inherited by the provider that is passed in.  This version is somewhat backward compatible in that it will not complain if project is supplied but it will not use it.

Also added connection name as an output since this is useful for passing to cloudsql proxy.