### PR TITLE
[GH-782] Add GCS bucket notification module

### DIFF
--- a/.github/workflows/TerraformTest-storage-bucket-notification.yml
+++ b/.github/workflows/TerraformTest-storage-bucket-notification.yml
@@ -1,4 +1,4 @@
-name: Terraform Test - wfl-instance module
+name: Terraform Test - storage-bucket-notification module
 
 env:
   terraform_directory: "terraform-modules/storage-bucket-notification"

--- a/.github/workflows/TerraformTest-storage-bucket-notification.yml
+++ b/.github/workflows/TerraformTest-storage-bucket-notification.yml
@@ -1,0 +1,54 @@
+name: Terraform Test - wfl-instance module
+
+env:
+  terraform_directory: "terraform-modules/storage-bucket-notification"
+  terraform_version: "0.12.25"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - terraform-modules/storage-bucket-notification/**
+
+jobs:
+  terraform_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Run Terraform fmt (kind of a linter)
+      - name: Terraform format check
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: ${{ env.terraform_version }}
+          tf_actions_subcommand: 'fmt'
+          tf_actions_fmt_write: false
+          tf_actions_comment: true
+          tf_actions_working_dir: ${{ env.terraform_directory }}/test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run Terraform init
+      - name: Terraform init
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: ${{ env.terraform_version }}
+          tf_actions_subcommand: 'init'
+          tf_actions_comment: true
+          tf_actions_working_dir: ${{ env.terraform_directory }}/test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run Terraform validate
+      - name: Terraform validate
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: ${{ env.terraform_version }}
+          tf_actions_subcommand: 'validate'
+          tf_actions_comment: true
+          tf_actions_working_dir: ${{ env.terraform_directory }}/test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/terraform-modules/storage-bucket-notification/README.md
+++ b/terraform-modules/storage-bucket-notification/README.md
@@ -10,7 +10,7 @@
 ```
 module "bucket_notification" {
   # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/storage-bucket-notification?ref=se-add-pubsub-modules"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/storage-bucket-notification?ref=storage-bucket-notification-0.0.1"
 
   bucket_name = "aou-input"
   topic_name = "aou-topic"

--- a/terraform-modules/storage-bucket-notification/README.md
+++ b/terraform-modules/storage-bucket-notification/README.md
@@ -1,0 +1,32 @@
+# Module for creating google bucket notifications
+
+- This module creates a Google Cloud Pub/Sub topic and configures a GCS bucket to publish to that topic.
+
+### Prerequisite
+- Terraform 0.12.+
+
+
+### Example Use
+```
+module "bucket_notification" {
+  # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/storage-bucket-notification?ref=se-add-pubsub-modules"
+
+  bucket_name = "aou-input"
+  topic_name = "aou-topic"
+}
+```
+
+## Inputs
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| bucket_name | The name of the bucket to use for configuring storage notifications| string | null | yes |
+| topic_name | The name of the pubsub topic to create | string | null | yes |
+
+## Outputs
+
+| Name | Description | Type | 
+|------|-------------|:----:|
+| topic | topic created | google resource | 
+| bucket_notification | the bucket notification created | google resource | 
+```

--- a/terraform-modules/storage-bucket-notification/notification.tf
+++ b/terraform-modules/storage-bucket-notification/notification.tf
@@ -1,0 +1,19 @@
+resource "google_storage_notification" "notification" {
+  bucket         = var.bucket_name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.topic.id
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on = [
+    google_pubsub_topic.topic,
+    google_pubsub_topic_iam_binding.binding]
+}
+
+// Enable notifications by giving the correct IAM permission to the unique service account.
+data "google_storage_project_service_account" "gcs_account" {
+}
+
+resource "google_pubsub_topic_iam_binding" "binding" {
+  topic   = google_pubsub_topic.topic.id
+  role    = "roles/pubsub.publisher"
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}

--- a/terraform-modules/storage-bucket-notification/outputs.tf
+++ b/terraform-modules/storage-bucket-notification/outputs.tf
@@ -1,0 +1,9 @@
+output "topic" {
+  description = "The PubSub topic."
+  value       = google_pubsub_topic.topic
+}
+
+output "bucket_notification" {
+  description = "The storage bucket notification."
+  value       = google_storage_notification.notification
+}

--- a/terraform-modules/storage-bucket-notification/test/.gitignore
+++ b/terraform-modules/storage-bucket-notification/test/.gitignore
@@ -1,0 +1,4 @@
+.terraform/*
+.terraform.d/*
+terraform.tfstate
+terraform.tfstate.backup

--- a/terraform-modules/storage-bucket-notification/test/test.tf
+++ b/terraform-modules/storage-bucket-notification/test/test.tf
@@ -1,0 +1,15 @@
+provider "google" {
+  project = "broad-gotc-dev"
+}
+
+module "test_storage_bucket_notification" {
+  # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
+  source = "../"
+
+  providers = {
+    google = google
+  }
+
+  bucket_name = "test-just-a-test"
+  topic_name  = "test-just-a-test"
+}

--- a/terraform-modules/storage-bucket-notification/topic.tf
+++ b/terraform-modules/storage-bucket-notification/topic.tf
@@ -1,0 +1,3 @@
+resource "google_pubsub_topic" "topic" {
+  name = var.topic_name
+}

--- a/terraform-modules/storage-bucket-notification/variables.tf
+++ b/terraform-modules/storage-bucket-notification/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "The name of the bucket."
+  type = string
+}
+
+variable "topic_name" {
+  description = "The name of the pub/sub topic."
+  type = string
+}

--- a/terraform-modules/storage-bucket-notification/versions.tf
+++ b/terraform-modules/storage-bucket-notification/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The module creates a Google pubsub topic and configures a bucket to publish to the topic on file upload events.