### PR TITLE
Changed External-dns and cloudsql-postgres

### DIFF
--- a/terraform-modules/cloudsql-postgres/README.md
+++ b/terraform-modules/cloudsql-postgres/README.md
@@ -4,3 +4,41 @@ It exposes the following variables:
    cloudsql_public_ip
 
 
+####  Public Example
+```
+module "sql" {
+  # terraform-shared repo
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=ms-externaldnsport"
+
+  providers = {
+    google.target = google-beta
+  }
+
+  project                       = myproject
+  cloudsql_name                 = myproject
+  cloudsql_version              = "POSTGRES_11"
+  cloudsql_authorized_networks  = var.broad_range_cidrs ## string list
+
+
+}
+
+```
+####  Private Example
+```
+module "sql" {
+  # terraform-shared repo
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=ms-externaldnsport"
+
+  providers = {
+    google.target = google-beta
+  }
+
+  project                       = myproject
+  cloudsql_name                 = myproject
+  cloudsql_version              = "POSTGRES_11"
+  cloudsql_authorized_networks  = var.broad_range_cidrs ## string list
+  private_enable                = true
+  private_network               = jade-network
+
+}
+```

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -42,7 +42,8 @@ resource "google_sql_database_instance" "cloudsql_instance" {
 #    }
 
     ip_configuration {
-      ipv4_enabled  = true
+      ipv4_enabled  = "${var.private_enable == true ? false : true}"
+      private_network = "${var.private_enable == true ? data.google_compute_network.network.id : null}"
       require_ssl   = true
       dynamic "authorized_networks" {
         for_each = var.cloudsql_authorized_networks
@@ -54,4 +55,31 @@ resource "google_sql_database_instance" "cloudsql_instance" {
 
     user_labels = var.cloudsql_instance_labels
   }
+}
+## private sql instance code
+data google_compute_network project_network {
+  count = var.private_enable ? 1 : 0
+
+  provider = google.target
+  name = var.private_network
+}
+
+resource "google_compute_global_address" "private_ip_address" {
+  count = var.private_enable ? 1 : 0
+
+  provider      = google.target
+  name          = "${var.cloudsql_name}-private-address"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.network.id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  count = var.private_enable ? 1 : 0
+
+  provider                = google.target
+  network                 = data.google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -143,5 +143,6 @@ variable "private_enable" {
 
 variable "private_network" {
   type = string
+  default = null
   description = "Name of the projects network that the NAT/VPC pairing sql ip will be put on."
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -132,3 +132,16 @@ variable "cloudsql_authorized_networks" {
   description = "CloudSQL authorized  networks"
   default = []
 }
+
+# private sql vars
+
+variable "private_enable" {
+  type = bool
+  description = "Enable flag for a private sql instance if set to true, a private sql isntance will be created."
+  default = false
+}
+
+variable "private_network" {
+  type = string
+  description = "Name of the projects network that the NAT/VPC pairing sql ip will be put on."
+}

--- a/terraform-modules/external-dns/README.md
+++ b/terraform-modules/external-dns/README.md
@@ -1,41 +1,39 @@
 # Module for creating DNS
 
-- This module creates dynamic A record, CNAME and more from a map variable
+- This module creates dynamic A record, CNAME and ip
 
 ### Prerequisite
 - Terraform 0.12.6+
 
 ### Example Use
 ```
-variable "records" {
-  default = {
-    record1 = {
-      type = "A"
-      rrdatas = "192.163.155.12"
-    },
-    recordcname2 = {
-      type = "CNAME"
-      rrdatas = "record1.datarepo-dev.broadinstitute.org."
-    },
-    record3 = {
-      type = "A"
-      rrdatas = "192.55.77.11"
-    }
+provider google-beta {
+  alias = "target"
+  credentials = file("account.json")
+  project = "broad-jade-dev"
+  region = "us-central1"
+}
+
+provider google-beta {
+  alias = "dev-core"
+
+  project = "broad-jade-dev"
+  region = "us-central1"
+}
+
+data google_dns_managed_zone dev_zone {
+  provider = google-beta.dev-core
+  name = "datarepo-dev"
+}
+
+module dns_names {
+  source = "../"
+  providers = {
+    google.ip = google-beta.target,
+    google.dns = google-beta.dev-core
   }
+  zone_gcp_name = data.google_dns_managed_zone.dev_zone.name
+  zone_dns_name = data.google_dns_managed_zone.dev_zone.dns_name
+  dns_names = ["cheese", "pizza"]
 }
-
-module "dns-test" {
-  # terraform-shared repo
-  source     = "github.com/broadinstitute/terraform-shared.git//terraform-modules/external-dns?ref=ms-dns-creator-v2"
-
-  target_dns_zone_name = "datarepo-dev"
-  records = var.records
-}
-```
-### Variables to set
-```
-#name of external dns_zone name
-variable "target_dns_zone_name" {}
-#name and destination values ie: record = 192.168.44.22
-variable "records" {}
 ```

--- a/terraform-modules/external-dns/provider.tf
+++ b/terraform-modules/external-dns/provider.tf
@@ -1,0 +1,11 @@
+provider google {
+  alias = "target"
+}
+
+provider google {
+  alias = "ip"
+}
+
+provider google {
+  alias = "dns"
+}

--- a/terraform-modules/external-dns/test/test.tf
+++ b/terraform-modules/external-dns/test/test.tf
@@ -1,0 +1,29 @@
+provider google-beta {
+  alias = "target"
+  credentials = file("account.json")
+  project = "broad-jade-dev"
+  region = "us-central1"
+}
+
+provider google-beta {
+  alias = "dev-core"
+
+  project = "broad-jade-dev"
+  region = "us-central1"
+}
+
+data google_dns_managed_zone dev_zone {
+  provider = google-beta.dev-core
+  name = "datarepo-dev"
+}
+
+module dns_names {
+  source = "../"
+  providers = {
+    google.ip = google-beta.target,
+    google.dns = google-beta.dev-core
+  }
+  zone_gcp_name = data.google_dns_managed_zone.dev_zone.name
+  zone_dns_name = data.google_dns_managed_zone.dev_zone.dns_name
+  dns_names = ["cheese", "pizza"]
+}

--- a/terraform-modules/external-dns/variables.tf
+++ b/terraform-modules/external-dns/variables.tf
@@ -1,8 +1,20 @@
-#name of external dns_zone name
-variable "target_dns_zone_name" {
-  type = string
+variable dns_names {
+  type = list(string)
+  description = "List of DNS names to generate global IP addresses, A-records, and CNAME-records for."
 }
-#name and destination values ie: record = 192.168.44.22
-variable "records" {
-  type = map(object({type = string, rrdatas = string}))
+
+variable dependencies {
+  type = any
+  default = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+
+variable zone_gcp_name {
+  type = string
+  description = "GCP name for the managed DNS zone to generate records within."
+}
+
+variable zone_dns_name {
+  type = string
+  description = "DNS name of the zone to generate records within."
 }


### PR DESCRIPTION
external-dns new features:
- create ip from simple list
- create a record from simple list
-  create cname  from simple list

cloudsql-postgres new features:
- ability to create both public or private sql instances
