### PR TITLE
Re-generate CloudSQL instance ID on version change

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -6,6 +6,10 @@ resource "random_id" "cloudsql_id" {
   count = var.enable ? 1 : 0
 
   byte_length   = 8
+
+  keepers = {
+    database_version = var.cloudsql_version
+  }
 }
 
 resource "google_sql_database_instance" "cloudsql_instance" {


### PR DESCRIPTION
Without this change, if TF tries to change the version of a CloudSQL instance, it will try to re-create it with the same ID.