### PR TITLE
[GH-875] Make WFL instance DBs tagged with 'wfl'

### DIFF
--- a/terraform-modules/wfl-instance/postgres.tf
+++ b/terraform-modules/wfl-instance/postgres.tf
@@ -8,6 +8,9 @@ module "postgres" {
   cloudsql_name              = "${var.instance_id}-wfl"
   cloudsql_version           = "POSTGRES_11"
   cloudsql_tier              = "db-custom-1-3840"
+  cloudsql_instance_labels   = {
+    wfl = "true"
+  }
   postgres_availability_type = "ZONAL"
   app_dbs = {
     default = {


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GH-875

WFL instance DB names have some randomized stuff after the "{instance_id}-wfl" bit and detecting the "-wfl-" in the name is brittle. I figured I could just pass a value for [this variable](https://github.com/broadinstitute/terraform-shared/blob/master/terraform-modules/cloudsql-postgres/variables.tf#L131) so that DBs that get created via this module have a Python-truthy "wfl" tag.

Over in WFL's deployment we can just query a project's Cloud SQL instances, filter for what has a truthy "wfl" tag (since None is falsy), and use that if we just find one.

Dunno how to apply this change, so-to-speak, is it just a matter of `plan` and `apply` in places where instances are used (just `gotc-deploy/deploy/aou` right now) or is there a version number we need to bump for it to catch this upstream change?