### PR TITLE
update log sinks so it can run without enabling BQ

### DIFF
--- a/terraform-modules/gcs_bq_log_sink/log_sinks.tf
+++ b/terraform-modules/gcs_bq_log_sink/log_sinks.tf
@@ -20,6 +20,7 @@ resource "google_bigquery_dataset" "logs" {
 }
 
 resource "google_bigquery_dataset_access" "access" {
+  count         = var.enable_bigquery
   dataset_id    = google_bigquery_dataset.logs[0].dataset_id
   role          = "OWNER"
   special_group = "allAuthenticatedUsers"


### PR DESCRIPTION
Update google_bigquery_dataset_access to have a `count` argument of `var.enable_bigquery` like every other resource in this module that toggles on `enable_bigquery`. Otherwise this doesn't let you *not* use bigquery.