### PR TITLE
[GH-996] GitHub Runner built-in Docker now rootless

### DIFF
--- a/terraform-modules/github-runner/README.md
+++ b/terraform-modules/github-runner/README.md
@@ -4,7 +4,7 @@ This module creates some number of self-hosted GitHub runners for a specific rep
 ```hcl
 module "test_runner" {
   # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.1.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.2.0"
 
   providers = {
     google = google.broad-gotc-dev
@@ -62,7 +62,7 @@ Out-of-the-box on each runner you get:
 - Vault preinstalled and authenticated (via the given role/secret ID paths)
 - GCP utilities preinstalled and authenticated (for `service-account` with `service-account-scopes`)
 - Docker (and kubectl) preinstalled and `gcloud` set as a credential helper
-  - Docker runs in [rootless mode](https://docs.docker.com/engine/security/rootless/) to simplify permissions and enhance security -- "root" in containers maps to the normal user that runs actions 
+  - Docker runs in [rootless mode](https://docs.docker.com/engine/security/rootless/) to simplify permissions and enhance security -- the root user inside containers maps to the normal user that runs actions on the host
 - Automatic registration with the target GitHub repo on startup (and de-registration on shutdown)
 - Automatic restarts every night at 3 AM to update everything to latest version (Docker, Vault, kubectl, OS via `apt-get update`, GitHub Action Runner software)
 

--- a/terraform-modules/github-runner/shutdown-script.sh
+++ b/terraform-modules/github-runner/shutdown-script.sh
@@ -17,4 +17,4 @@ pushd ./runner
 ./svc.sh stop
 ./svc.sh uninstall
 
-sudo -Hiu "$ACTIONS_USER" -H ./config.sh remove --token "$REMOVAL_TOKEN"
+sudo -Hiu "$ACTIONS_USER" bash -c "cd /runner; ./config.sh remove --token '$REMOVAL_TOKEN'"

--- a/terraform-modules/github-runner/shutdown-script.sh
+++ b/terraform-modules/github-runner/shutdown-script.sh
@@ -17,4 +17,4 @@ pushd ./runner
 ./svc.sh stop
 ./svc.sh uninstall
 
-sudo -u "$ACTIONS_USER" -H ./config.sh remove --token "$REMOVAL_TOKEN"
+sudo -Hiu "$ACTIONS_USER" -H ./config.sh remove --token "$REMOVAL_TOKEN"

--- a/terraform-modules/github-runner/startup-script.sh
+++ b/terraform-modules/github-runner/startup-script.sh
@@ -54,7 +54,7 @@ sudo snap install --classic kubectl
 rm -rf "/home/$ACTIONS_USER/.docker/run"
 sudo -Hiu "$ACTIONS_USER" bash -c "curl -fsSL https://get.docker.com/rootless | sh"
 rm -f "/docker.log"
-sudo -Hiu "$ACTIONS_USER" nohup /home/actions/bin/dockerd-rootless.sh --experimental >"/docker.log" 2>&1 &
+sudo -Hiu "$ACTIONS_USER" XDG_RUNTIME_DIR="/home/$ACTIONS_USER/.docker/run" nohup /home/actions/bin/dockerd-rootless.sh --experimental >"/docker.log" 2>&1 &
 echo "Docker logs available in /docker.log"
 
 # Configure Vault agent

--- a/terraform-modules/github-runner/startup-script.sh
+++ b/terraform-modules/github-runner/startup-script.sh
@@ -124,11 +124,18 @@ pushd ./runner
 if [[ -z "$RUNNER_LABELS" ]]; then
     sudo -Hiu "$ACTIONS_USER" bash -c \
         "cd /runner; \
-        ./config.sh --unattended --url 'https://github.com/${REPO}' --token '$REGISTRATION_TOKEN' --name '$RUNNER_NAME'"
+        ./config.sh --unattended --replace \
+        --url 'https://github.com/${REPO}' \
+        --token '$REGISTRATION_TOKEN' \
+        --name '$RUNNER_NAME'"
 else
     sudo -Hiu "$ACTIONS_USER" bash -c \
         "cd /runner; \
-        ./config.sh --unattended --url 'https://github.com/${REPO}' --token '$REGISTRATION_TOKEN' --name '$RUNNER_NAME' --labels '$RUNNER_LABELS'"
+        ./config.sh --unattended --replace \
+        --url 'https://github.com/${REPO}' \
+        --token '$REGISTRATION_TOKEN' \
+        --name '$RUNNER_NAME' \
+        --labels '$RUNNER_LABELS'"
 fi
 
 ./svc.sh install "$ACTIONS_USER"

--- a/terraform-modules/github-runner/startup-script.sh
+++ b/terraform-modules/github-runner/startup-script.sh
@@ -122,9 +122,13 @@ pushd ./runner
 
 # Start runner
 if [[ -z "$RUNNER_LABELS" ]]; then
-    sudo -Hiu "$ACTIONS_USER" ./config.sh --unattended --url "https://github.com/${REPO}" --token "$REGISTRATION_TOKEN" --name "$RUNNER_NAME"
+    sudo -Hiu "$ACTIONS_USER" bash -c \
+        "cd /runner; \
+        ./config.sh --unattended --url 'https://github.com/${REPO}' --token '$REGISTRATION_TOKEN' --name '$RUNNER_NAME'"
 else
-    sudo -Hiu "$ACTIONS_USER" ./config.sh --unattended --url "https://github.com/${REPO}" --token "$REGISTRATION_TOKEN" --name "$RUNNER_NAME" --labels "$RUNNER_LABELS"
+    sudo -Hiu "$ACTIONS_USER" bash -c \
+        "cd /runner; \
+        ./config.sh --unattended --url 'https://github.com/${REPO}' --token '$REGISTRATION_TOKEN' --name '$RUNNER_NAME' --labels '$RUNNER_LABELS'"
 fi
 
 ./svc.sh install "$ACTIONS_USER"

--- a/terraform-modules/github-runner/test/test.tf
+++ b/terraform-modules/github-runner/test/test.tf
@@ -5,7 +5,7 @@ provider "google" {
 
 module "test_runner" {
   # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.1.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.2.0"
 
   providers = {
     google = google.broad-gotc-dev


### PR DESCRIPTION
Since the github-runner module runs GitHub Actions as a non-root user, we run into an unfortunate issue where steps that use Docker containers to modify the files on the host can accidentally create things that only `root` -- not the non-root `actions` user -- can access/modify. This means that subsequent steps (even in future invocations) can fail if they do not also use Docker containers to work with the host file system.

> Observed where the `hashicorp/terraform-github-actions` init action artifacts can't be cleaned up by a later `actions/checkout` step. See more info [here](https://vsupalov.com/docker-shared-permissions/).

Skip to the bottom if you don't care about the litany of other fixes that won't work for one reason or another:

- **Use `setfacl -Rdm` and `setgid` to try to persist `actions` permissions over the files** -- tested but `root` can casually and silently ignore the ACL to bar the "group" (`actions`) from having write permissions
- **Use `chown` to fix ownership** -- no reasonable way to automate this and it would be an esoteric manual step
- **Modify Docker containers to drop root privileges** -- this would involve forking arbitrary third-party actions since we lack control
- **Map the root user in Docker containers to the `actions` user [manually by ID aliasing](https://www.jujens.eu/posts/en/2017/Jul/02/docker-userns-remap/)** -- brittle and difficult to script
- **Use Docker `userns-remap` to have Docker handle the ID aliasing** -- tested but didn't work because it effectively does the reverse of what we want: inside the container the user doesn't look like root but outside the container the user is still root on the filesystem (because the daemon is)

The solution which ended up working:
- **Use Docker's rootless mode to run the entire system as the `actions` user** -- "`root`" inside the container now can't be anything other than `actions` on the outside, problem solved

Rootless Docker only plays nice with `systemctl` if you use `systemctl --user`, which doesn't seem to play nice in GCE. Not an issue I was interested in debugging extensively since we can just `nohup &` the Docker daemon inside the startup script like we do Vault Agent. There's some small changes made to environment variable handling so that Actions can still find `docker` and the socket. Free bonus is that now the runner is more secure since Docker isn't `root`.

## Post-merge
Tag the head of master with `github-runner-0.2.0`