### PR TITLE
Add capability to pass in database_flags as a map

### DIFF
--- a/terraform-modules/cloudsql-mysql/cloudsql.tf
+++ b/terraform-modules/cloudsql-mysql/cloudsql.tf
@@ -3,41 +3,41 @@
 #
 
 resource "random_id" "cloudsql-id" {
-  byte_length   = 8
+  byte_length = 8
 }
 
 resource "google_sql_database_instance" "cloudsql-instance" {
-  provider              = "google.target"
-  project =  "${var.project}"
-  count                 = "${var.enable_flag}"
-  region                = "${var.cloudsql_region}"
-  database_version      = "${var.cloudsql_version}"
-  name                  = "${var.cloudsql_name}-${random_id.cloudsql-id.hex}"
-  depends_on            = [ "random_id.cloudsql-id" ]
+  provider         = google.target
+  project          = var.project
+  count            = var.enable_flag
+  region           = var.cloudsql_region
+  database_version = var.cloudsql_version
+  name             = "${var.cloudsql_name}-${random_id.cloudsql-id.hex}"
+  depends_on       = [random_id.cloudsql-id]
 
   settings {
 
-    activation_policy   = "${var.cloudsql_activation_policy}"
-    disk_autoresize     = "${var.cloudsql_disk_autoresize}"
-    disk_type           = "${var.cloudsql_disk_type}"
-    replication_type    = "${var.cloudsql_replication_type}"
-    tier                = "${var.cloudsql_tier}"
+    activation_policy = var.cloudsql_activation_policy
+    disk_autoresize   = var.cloudsql_disk_autoresize
+    disk_type         = var.cloudsql_disk_type
+    replication_type  = var.cloudsql_replication_type
+    tier              = var.cloudsql_tier
 
     backup_configuration {
-      binary_log_enabled    = false
-      enabled               = true
-      start_time            = "06:00"
+      binary_log_enabled = false
+      enabled            = true
+      start_time         = "06:00"
     }
 
-#    maintenance_window {
-#        day             = "${var.cloudsql_maintenance_window_day}"
-#        hour            = "${var.cloudsql_maintenance_window_hour}"
-#        update_track    = "${var.cloudsql_maintenance_window_update_track}"
-#    }
+    #    maintenance_window {
+    #        day             = "${var.cloudsql_maintenance_window_day}"
+    #        hour            = "${var.cloudsql_maintenance_window_hour}"
+    #        update_track    = "${var.cloudsql_maintenance_window_update_track}"
+    #    }
 
     ip_configuration {
-      ipv4_enabled  = true
-      require_ssl   = true
+      ipv4_enabled = true
+      require_ssl  = true
       dynamic "authorized_networks" {
         for_each = var.cloudsql_authorized_networks
         content {
@@ -49,12 +49,12 @@ resource "google_sql_database_instance" "cloudsql-instance" {
     dynamic "database_flags" {
       for_each = var.cloudsql_database_flags
       content {
-       name  = database_flags.key
-       value = database_flags.value
+        name  = database_flags.key
+        value = database_flags.value
       }
     }
-      
-    user_labels = "${var.cloudsql_instance_labels}"
+
+    user_labels = var.cloudsql_instance_labels
 
   }
 }

--- a/terraform-modules/cloudsql-mysql/cloudsql.tf
+++ b/terraform-modules/cloudsql-mysql/cloudsql.tf
@@ -46,51 +46,14 @@ resource "google_sql_database_instance" "cloudsql-instance" {
       }
     }
 
-    database_flags {
-      name  = "log_output"
-      value = "FILE"
+    dynamic "database_flags" {
+      for_each = var.cloudsql_database_flags
+      content {
+       name  = database_flags.key
+       value = database_flags.value
+      }
     }
-
-    database_flags {
-      name  = "sql_mode"
-      value = "STRICT_ALL_TABLES"
-    }
-
-    database_flags {
-      name  = "slow_query_log"
-      value = "on"
-    }
-
-    database_flags {
-      name  = "general_log"
-      value = "on"
-    }
-
-    database_flags {
-      name  = "query_cache_type"
-      value = "1"
-    }
-
-    database_flags {
-      name  = "query_cache_limit"
-      value = "1048576"
-    }
-
-    database_flags {
-      name  = "query_cache_size"
-      value = "10485760"
-    }
-
-    database_flags {
-      name  = "innodb_autoinc_lock_mode"
-      value = "2"
-    }
-
-    database_flags {
-      name  = "max_allowed_packet"
-      value = "1073741824"
-    }
-
+      
     user_labels = "${var.cloudsql_instance_labels}"
 
   }

--- a/terraform-modules/cloudsql-mysql/database.tf
+++ b/terraform-modules/cloudsql-mysql/database.tf
@@ -1,12 +1,12 @@
 
 
 resource "google_sql_database" "app-database" {
-  provider              = "google.target"
-  count = "${var.enable_flag}"
-  name = "${var.cloudsql_database_name}"
-  project   = var.project
-  instance  = "${var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""}"
-  charset   = "utf8"
-  collation = "utf8_general_ci"
-  depends_on = ["google_sql_database_instance.cloudsql-instance" ]
+  provider   = google.target
+  count      = var.enable_flag
+  name       = var.cloudsql_database_name
+  project    = var.project
+  instance   = var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""
+  charset    = "utf8"
+  collation  = "utf8_general_ci"
+  depends_on = [google_sql_database_instance.cloudsql-instance]
 }

--- a/terraform-modules/cloudsql-mysql/users.tf
+++ b/terraform-modules/cloudsql-mysql/users.tf
@@ -1,27 +1,27 @@
 
 resource "random_id" "random-password" {
-  byte_length   = 16
+  byte_length = 16
 }
 
 resource "google_sql_user" "app-user" {
-  provider              = "google.target"
-  count                 = "${var.enable_flag}"
-  project   = var.project
-  instance  = "${var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""}"
-  name      = "${var.cloudsql_database_user_name}"
-  host      = "%"
-  password  = "${var.cloudsql_database_user_password == ""?random_id.random-password.hex:var.cloudsql_database_user_password}"
-  depends_on = ["google_sql_database_instance.cloudsql-instance" ]
+  provider   = google.target
+  count      = var.enable_flag
+  project    = var.project
+  instance   = var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""
+  name       = var.cloudsql_database_user_name
+  host       = "%"
+  password   = var.cloudsql_database_user_password == "" ? random_id.random-password.hex : var.cloudsql_database_user_password
+  depends_on = [google_sql_database_instance.cloudsql-instance]
 }
 
 resource "google_sql_user" "root-user" {
-  provider              = "google.target"
-  count                 = "${var.enable_flag}"
-  project   = var.project
-  instance  = "${var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""}"
-  name      = "root"
-  host      = "%"
-  password  = "${var.cloudsql_database_root_password == ""?random_id.random-password.hex:var.cloudsql_database_root_password}"
-  depends_on = ["google_sql_database_instance.cloudsql-instance" ]
+  provider   = google.target
+  count      = var.enable_flag
+  project    = var.project
+  instance   = var.enable_flag ? google_sql_database_instance.cloudsql-instance.0.name : ""
+  name       = "root"
+  host       = "%"
+  password   = var.cloudsql_database_root_password == "" ? random_id.random-password.hex : var.cloudsql_database_root_password
+  depends_on = [google_sql_database_instance.cloudsql-instance]
 }
 

--- a/terraform-modules/cloudsql-mysql/variables.tf
+++ b/terraform-modules/cloudsql-mysql/variables.tf
@@ -102,3 +102,18 @@ variable "cloudsql_authorized_networks" {
   type = list(string)
   default = []
 }
+
+variable "cloudsql_database_flags" {
+  type = map
+  default = {
+   "log_output" = "FILE",
+   "sql_mode" = "STRICT_ALL_TABLES",
+   "slow_query_log" = "on",
+   "general_log" = "on",
+   "query_cache_type" = "1",
+   "query_cache_limit" = "1048576",
+   "query_cache_size" = "10485760",
+   "innodb_autoinc_lock_mode" = "2",
+   "max_allowed_packet" = "1073741824",
+  }
+}

--- a/terraform-modules/cloudsql-mysql/variables.tf
+++ b/terraform-modules/cloudsql-mysql/variables.tf
@@ -5,115 +5,115 @@ variable "project" {}
 
 # enable/disable var
 variable "enable_flag" {
-   default = "1"
+  default = "1"
 }
 
 variable "cloudsql_name" {
-  default = "cloudsql"
+  default     = "cloudsql"
   description = "DNS CNAME record target hostname for default mysql instance in an env. Should be set as a vault env override for each env."
 }
 
 variable "cloudsql_region" {
-  default = "us-central1"
+  default     = "us-central1"
   description = "The region for CloudSQL instances. NOTE: For Gen 2 instance, use standard gcloud regions."
 }
 
 variable "cloudsql_version" {
-  default = "MYSQL_5_6"
+  default     = "MYSQL_5_6"
   description = "The version of MySQL to use for CloudSQL instances."
 }
 
 variable "cloudsql_require_ssl" {
-  default = "true"
+  default     = "true"
   description = "Determines if SSL is required for connections to CloudSQL instances."
 }
 
 variable "cloudsql_tier" {
-  default = "db-n1-standard-1"
+  default     = "db-n1-standard-1"
   description = "The default tier (DB instance size) for CloudSQL instances"
 }
 
 variable "cloudsql_disk_autoresize" {
-  default = "true"
+  default     = "true"
   description = "Determines if the CloudSQL instances will increase their disk size automatically"
 }
 
 variable "cloudsql_disk_type" {
-  default = "PD_SSD"
+  default     = "PD_SSD"
   description = "The default disk type for CloudSQL instances"
 }
 
 variable "cloudsql_activation_policy" {
-  default = "ALWAYS"
+  default     = "ALWAYS"
   description = "The default MySQL activation policy for CloudSQL instances"
 }
 
 variable "cloudsql_replication_type" {
-  default = "SYNCHRONOUS"
+  default     = "SYNCHRONOUS"
   description = "The default MySQL replication type for CloudSQL instances"
 }
 
 variable "cloudsql_maintenance_window_enable" {
-  default = "0"
+  default     = "0"
   description = "Enable custom GCE sql instance maintenance window for CloudSQL instances."
 }
 
 variable "cloudsql_maintenance_window_day" {
-  default = "6"
+  default     = "6"
   description = "The default day of the week for the custom GCE sql instance maintenance window for CloudSQL instances. Valid values: 1-7 (Monday = 1; Sunday = 7)."
 }
 
 variable "cloudsql_maintenance_window_hour" {
-  default = "7"
+  default     = "7"
   description = "The default hour of the day for the custom GCE sql instance maintenance window for CloudSQL instances. Valid values: 0-23."
 }
 
 variable "cloudsql_maintenance_window_update_track" {
-  default = "stable"
+  default     = "stable"
   description = "The default update track for determining the relative order for receiving GCE sql instance updates during a maintenance window for CloudSQL instances. Valid values: stable (receive later), or canary (receive earlier). Note: These values are relative to each other for GCE sql instances within a single GCE project."
 }
 
 variable "cloudsql_database_name" {
-  default = "database"
+  default     = "database"
   description = "The default database name if not specified"
 }
 
 variable "cloudsql_database_user_name" {
-  default = "appuser"
+  default     = "appuser"
   description = "The default database application user name if not specified"
 }
 
 variable "cloudsql_database_user_password" {
-  default = ""
+  default     = ""
   description = "The default database application user password if not specified"
 }
 
 variable "cloudsql_database_root_password" {
-  default = ""
+  default     = ""
   description = "The default database root user password if not specified"
 }
 
 variable "cloudsql_instance_labels" {
-  type = "map"
+  type    = map
   default = {}
 }
 
 variable "cloudsql_authorized_networks" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "cloudsql_database_flags" {
   type = map
   default = {
-   "log_output" = "FILE",
-   "sql_mode" = "STRICT_ALL_TABLES",
-   "slow_query_log" = "on",
-   "general_log" = "on",
-   "query_cache_type" = "1",
-   "query_cache_limit" = "1048576",
-   "query_cache_size" = "10485760",
-   "innodb_autoinc_lock_mode" = "2",
-   "max_allowed_packet" = "1073741824",
+    "log_output"               = "FILE",
+    "sql_mode"                 = "STRICT_ALL_TABLES",
+    "slow_query_log"           = "on",
+    "general_log"              = "on",
+    "query_cache_type"         = "1",
+    "query_cache_limit"        = "1048576",
+    "query_cache_size"         = "10485760",
+    "innodb_autoinc_lock_mode" = "2",
+    "max_allowed_packet"       = "1073741824",
   }
 }


### PR DESCRIPTION
In addition to the above improvement, this PR also covers some formatting and version 0.12 deprecation fixes.  Essentially changes that work in 0.12 but are destined to be deprecated in future versions.