### PR TITLE
DDO-832 k8s-node-pool: set initial_node_count when autoscaling is used

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -8,6 +8,12 @@ resource google_container_node_pool pool {
 
   # Scaling settings -- only one of node_count or autoscaling should be supplied
   node_count = var.node_count
+
+  # When using autoscaling, initial_node_count must be set, otherwise
+  # an empty node pool is created, even if the minimum is > 0
+  # (See https://github.com/hashicorp/terraform-provider-google/issues/2126)
+  initial_node_count = var.autoscaling == null ? null : var.autoscaling.min_node_count
+
   dynamic "autoscaling" {
     for_each = var.autoscaling == null ? [] : [var.autoscaling]
 

--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -1,6 +1,8 @@
 resource google_container_node_pool pool {
   provider = google-beta
 
+  count = var.enable ? 1 : 0
+
   depends_on = [var.dependencies]
   name       = var.name
   location   = var.location

--- a/terraform-modules/k8s-node-pool/variables.tf
+++ b/terraform-modules/k8s-node-pool/variables.tf
@@ -5,6 +5,12 @@ variable dependencies {
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules"
 }
 
+variable enable {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
 variable name {
   type        = string
   description = "Name to assign to the node pool."


### PR DESCRIPTION
`k8s-node-pool` udpates:
* Set `initial_node_count` to `autoscaling.min_node_count` when autoscaling is enabled, otherwise an empty pool will be created, no matter what `min_node_count` is set to (See https://github.com/hashicorp/terraform-provider-google/issues/2126)
* Add `enable` flag