### PR TITLE
[GH-1121] Improve Docker reinstalls

### DIFF
--- a/terraform-modules/github-runner/startup-script.sh
+++ b/terraform-modules/github-runner/startup-script.sh
@@ -51,7 +51,7 @@ sudo apt-get -y install \
 sudo snap install --classic kubectl
 
 # Install/configure docker to run as actions user
-rm -rf "/home/$ACTIONS_USER/.docker/run"
+sudo rm -rf "/home/$ACTIONS_USER/bin/dockerd" "/home/$ACTIONS_USER/.docker/run"
 sudo -Hiu "$ACTIONS_USER" bash -c "curl -fsSL https://get.docker.com/rootless | sh"
 rm -f "/docker.log"
 sudo -Hiu "$ACTIONS_USER" XDG_RUNTIME_DIR="/home/$ACTIONS_USER/.docker/run" nohup /home/actions/bin/dockerd-rootless.sh --experimental >"/docker.log" 2>&1 &

--- a/terraform-modules/github-runner/test/test.tf
+++ b/terraform-modules/github-runner/test/test.tf
@@ -5,7 +5,7 @@ provider "google" {
 
 module "test_runner" {
   # "github.com/" + org + "/" + repo name + ".git" + "//" + path within repo to base dir + "?ref=" + git object ref
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.2.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/github-runner?ref=github-runner-0.2.1"
 
   providers = {
     google = google.broad-gotc-dev


### PR DESCRIPTION
Addresses [https://broadinstitute.atlassian.net/browse/GH-1121](https://broadinstitute.atlassian.net/browse/GH-1121) by deleting not only the usual XDG_RUNTIME_DIRECTORY on startup but also the normal rootless docker install folder at `"/home/$ACTIONS_USER/bin/dockerd"`. Since we need the installation process to help set up docker, making sure that folder is gone means the install will go smoothly.