### PR TITLE
DDO-1107 cloudsql-postgres: Make it possible to specify insights_config

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -66,8 +66,11 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       }
     }
 
-    insights_config {
-      query_insights_enabled = var.cloudsql_insights_config.query_insights_enabled
+    dynamic "insights_config" {
+      for_each = var.cloudsql_insights_config
+      content {
+        insights_config.key = insights_config.value
+      }
     }
   }
 }

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -58,9 +58,12 @@ resource "google_sql_database_instance" "cloudsql_instance" {
 
     user_labels = var.cloudsql_instance_labels
 
-    database_flags {
-      name  = "max_connections"
-      value = var.postgres_max_connections
+    dynamic "database_flags" {
+      for_each = var.cloudsql_database_flags
+      content {
+        name  = database_flags.key
+        value = database_flags.value
+      }
     }
 
     insights_config {

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -66,11 +66,8 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       }
     }
 
-    dynamic "insights_config" {
-      for_each = var.cloudsql_insights_config
-      content {
-        insights_config.key = insights_config.value
-      }
+    insights_config {
+      query_insights_enabled = var.cloudsql_insights_config.query_insights_enabled
     }
   }
 }

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -67,7 +67,10 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     }
 
     insights_config {
-      query_insights_enabled = var.cloudsql_insights_config.query_insights_enabled
+      query_insights_enabled  = var.cloudsql_insights_config.query_insights_enabled
+      query_string_length     = var.cloudsql_insights_config.query_string_length
+      record_application_type = var.cloudsql_insights_config.record_application_type
+      record_client_address   = var.cloudsql_insights_config.record_client_address
     }
   }
 }

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -69,7 +69,7 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     insights_config {
       query_insights_enabled  = var.cloudsql_insights_config.query_insights_enabled
       query_string_length     = var.cloudsql_insights_config.query_string_length
-      record_application_type = var.cloudsql_insights_config.record_application_type
+      record_application_tags = var.cloudsql_insights_config.record_application_tags
       record_client_address   = var.cloudsql_insights_config.record_client_address
     }
   }

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -63,7 +63,9 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       value = var.postgres_max_connections
     }
 
-    insights_config = var.cloudsql_insights_config
+    insights_config {
+      query_insights_enabled = var.cloudsql_insights_config.query_insights_enabled
+    }
   }
 }
 ## private sql instance code

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -3,7 +3,7 @@
 #
 
 resource "random_id" "cloudsql_id" {
-  count       = var.enable ? 1 : 0
+  count = var.enable ? 1 : 0
 
   byte_length = 8
 
@@ -19,7 +19,7 @@ resource "google_sql_database_instance" "cloudsql_instance" {
   region           = var.cloudsql_region
   database_version = var.cloudsql_version
   name             = "${var.cloudsql_name}-${random_id.cloudsql_id[0].hex}"
-  depends_on       = [ random_id.cloudsql_id, var.dependencies, google_service_networking_connection.private_vpc_connection ]
+  depends_on       = [random_id.cloudsql_id, var.dependencies, google_service_networking_connection.private_vpc_connection]
 
   settings {
 
@@ -62,6 +62,8 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       name  = "max_connections"
       value = var.postgres_max_connections
     }
+
+    insights_config = var.cloudsql_insights_config
   }
 }
 ## private sql instance code

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -67,10 +67,10 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     }
 
     insights_config {
-      query_insights_enabled  = var.cloudsql_insights_config.query_insights_enabled
-      query_string_length     = var.cloudsql_insights_config.query_string_length
-      record_application_tags = var.cloudsql_insights_config.record_application_tags
-      record_client_address   = var.cloudsql_insights_config.record_client_address
+      query_insights_enabled  = local.cloudsql_insights_config.query_insights_enabled
+      query_string_length     = local.cloudsql_insights_config.query_string_length
+      record_application_tags = local.cloudsql_insights_config.record_application_tags
+      record_client_address   = local.cloudsql_insights_config.record_client_address
     }
   }
 }

--- a/terraform-modules/cloudsql-postgres/test/test.tf
+++ b/terraform-modules/cloudsql-postgres/test/test.tf
@@ -5,7 +5,7 @@ provider "google" {
 module "test_postgres" {
   source = "../"
 
-  database_flags = {
+  clousql_database_flags = {
     max_connections = 100
   }
 

--- a/terraform-modules/cloudsql-postgres/test/test.tf
+++ b/terraform-modules/cloudsql-postgres/test/test.tf
@@ -5,6 +5,10 @@ provider "google" {
 module "test_postgres" {
   source = "../"
 
+  database_flags = {
+    max_connections = 100
+  }
+
   providers = {
     google              = google
     google.dns_provider = google

--- a/terraform-modules/cloudsql-postgres/test/test.tf
+++ b/terraform-modules/cloudsql-postgres/test/test.tf
@@ -5,7 +5,7 @@ provider "google" {
 module "test_postgres" {
   source = "../"
 
-  clousql_database_flags = {
+  cloudsql_database_flags = {
     max_connections = 100
   }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,8 +86,8 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = object({ query_insights_enabled = bool })
-  default     = { query_insights_enabled = false }
+  type        = map
+  default     = {}
   description = "Config parameters for Query Insights" # https://github.com/hashicorp/terraform-provider-google/pull/8434
 }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -44,8 +44,8 @@ variable "cloudsql_version" {
 }
 
 variable "cloudsql_keepers" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
 }
 
@@ -83,6 +83,12 @@ variable "cloudsql_replication_type" {
   type        = string
   default     = "SYNCHRONOUS"
   description = "The default replication type for CloudSQL instances"
+}
+
+variable "cloudsql_insights_config" {
+  type        = map(string)
+  default     = {}
+  description = "Config parameters for Query Insights" # https://github.com/hashicorp/terraform-provider-google/pull/8434
 }
 
 variable "postgres_availability_type" {
@@ -149,26 +155,26 @@ variable "cloudsql_authorized_networks" {
 # private sql vars
 
 variable "private_enable" {
-  type = bool
+  type        = bool
   description = "Enable flag for a private sql instance if set to true, a private sql isntance will be created."
-  default = false
+  default     = false
 }
 
 variable "enable_private_services" {
-  type = bool
+  type        = bool
   description = "Enable flag for a private sql instance if set to true, a private sql isntance will be created."
-  default = false
+  default     = false
 }
 
 variable "existing_vpc_network" {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of the projects network that the NAT/VPC pairing sql ip will be put on."
 }
 
 variable "private_network_self_link" {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of the projects network that the NAT/VPC pairing sql ip will be put on."
 }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,8 +86,18 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = object({ query_insights_enabled = bool })
-  default     = { query_insights_enabled = false }
+  type = object({
+    query_insights_enabled  = boolean,
+    query_istring_length    = number,
+    record_application_type = boolean,
+    record_client_addres    = boolean
+  })
+  default = {
+    query_insights_enabled  = false,
+    query_string_length     = null,
+    record_application_type = null,
+    record_client_address   = null
+  }
   description = "Config parameters for Query Insights"
 }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -87,13 +87,17 @@ variable "cloudsql_replication_type" {
 
 variable "cloudsql_insights_config" {
   type = map
-  default = {
+  default =
+  description = "Config parameters for Query Insights"
+}
+locals {
+  cloudsql_insights_config_defaults = {
     query_insights_enabled  = false,
     query_string_length     = null,
     record_application_tags = null,
     record_client_address   = null
   }
-  description = "Config parameters for Query Insights"
+  cloudsql_insights_config = merge(local.cloudsql_insights_config_defaults, var.cloudsql_insights_config)
 }
 
 variable "postgres_availability_type" {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,8 +86,8 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = map
-  default     = {}
+  type        = object({ query_insights_enabled = bool })
+  default     = { query_insights_enabled = false }
   description = "Config parameters for Query Insights" # https://github.com/hashicorp/terraform-provider-google/pull/8434
 }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -97,6 +97,12 @@ variable "postgres_availability_type" {
   description = "Postgres availability type"
 }
 
+variable "cloudsql_database_flags" {
+  type        = map
+  default     = {}
+  description = "Database flags to pass to the CloudSQL instance"
+}
+
 variable "postgres_max_connections" {
   type        = number
   default     = 100

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,12 +86,7 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type = object({
-    query_insights_enabled  = bool,
-    query_istring_length    = number,
-    record_application_type = bool,
-    record_client_addres    = bool
-  })
+  type = map
   default = {
     query_insights_enabled  = false,
     query_string_length     = null,

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,8 +86,8 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = map(string)
-  default     = {}
+  type        = object({ query_insights_enabled = bool })
+  default     = { query_insights_enabled = false }
   description = "Config parameters for Query Insights" # https://github.com/hashicorp/terraform-provider-google/pull/8434
 }
 

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -103,12 +103,6 @@ variable "cloudsql_database_flags" {
   description = "Database flags to pass to the CloudSQL instance"
 }
 
-variable "postgres_max_connections" {
-  type        = number
-  default     = 100
-  description = "Maximum number of concurrent connections to the database server"
-}
-
 # variable "cloudsql_maintenance_window_enable" {
 #   default = "0"
 #   description = "Enable custom GCE sql instance maintenance window for CloudSQL instances."

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -88,7 +88,7 @@ variable "cloudsql_replication_type" {
 variable "cloudsql_insights_config" {
   type        = object({ query_insights_enabled = bool })
   default     = { query_insights_enabled = false }
-  description = "Config parameters for Query Insights" # https://github.com/hashicorp/terraform-provider-google/pull/8434
+  description = "Config parameters for Query Insights"
 }
 
 variable "postgres_availability_type" {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -87,10 +87,10 @@ variable "cloudsql_replication_type" {
 
 variable "cloudsql_insights_config" {
   type = object({
-    query_insights_enabled  = boolean,
+    query_insights_enabled  = bool,
     query_istring_length    = number,
-    record_application_type = boolean,
-    record_client_addres    = boolean
+    record_application_type = bool,
+    record_client_addres    = bool
   })
   default = {
     query_insights_enabled  = false,

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -90,7 +90,7 @@ variable "cloudsql_insights_config" {
   default = {
     query_insights_enabled  = false,
     query_string_length     = null,
-    record_application_type = null,
+    record_application_tags = null,
     record_client_address   = null
   }
   description = "Config parameters for Query Insights"

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,8 +86,8 @@ variable "cloudsql_replication_type" {
 }
 
 variable "cloudsql_insights_config" {
-  type = map
-  default =
+  type        = map
+  default     = {}
   description = "Config parameters for Query Insights"
 }
 locals {

--- a/terraform-modules/cloudsql-postgres/versions.tf
+++ b/terraform-modules/cloudsql-postgres/versions.tf
@@ -1,3 +1,8 @@
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    google = {
+      version = ">= 3.58.0"
+    }
+  }
 }


### PR DESCRIPTION
* Make it possible to enable [Query Insights](https://github.com/hashicorp/terraform-provider-google/pull/8434) on Postgres CloudSQL instances. This requires a very recent version of the Google provider, so I've added a version constraint.
* Replace `postgres_max_connections` variable with a more generic `cloudsql_database_flags` variable, shamelessly genked from the cloudsql-mysql module. I've done this so that we can **avoid specifying a default number of max connections**, because Google's defaults vary with instance size and keeping our defaults up to date with GCP's defaults is likely to be annoying.

Users of the module that depend on `postgres_max_connections` having a default of 100 should pass in `database_flags` instead:
```
    module "clousql-postgres" {
        ...
        database_flags = { max_connections = 100 }
    }
```

Related: https://github.com/broadinstitute/terraform-ap-deployments/pull/255