### PR TITLE
[AS-701] expose cloud sql backup retention settings

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -36,6 +36,9 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       binary_log_enabled = false
       enabled            = true
       start_time         = "06:00"
+      backup_retention_settings {
+        retained_backups = var.cloudsql_retained_backups
+      }
     }
 
     #    maintenance_window {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -187,6 +187,12 @@ variable "private_network_self_link" {
   description = "Name of the projects network that the NAT/VPC pairing sql ip will be put on."
 }
 
+variable "cloudsql_retained_backups" {
+  type        = number
+  default     = 7
+  description = "Number of days to retain backups"
+}
+
 locals {
   private_network = var.enable_private_services ? var.private_network_self_link : var.existing_vpc_network
 }


### PR DESCRIPTION
I am hoping (still quite new to Terraform and the Broad) to leverage comparatively recent functionality: https://github.com/hashicorp/terraform-provider-google/pull/8582 to retain cloud sql backups for longer than 7 days. 
