### PR TITLE
[DDO-1423] expose additional node pool count config

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -3,10 +3,11 @@ resource google_container_node_pool pool {
 
   count = var.enable ? 1 : 0
 
-  depends_on = [var.dependencies]
-  name       = var.name
-  location   = var.location
-  cluster    = var.master_name
+  depends_on        = [var.dependencies]
+  name              = var.name
+  location          = var.location
+  cluster           = var.master_name
+  max_pods_per_node = var.max_pods_per_node
 
   # Scaling settings -- only one of node_count or autoscaling should be supplied
   node_count = var.node_count

--- a/terraform-modules/k8s-node-pool/variables.tf
+++ b/terraform-modules/k8s-node-pool/variables.tf
@@ -26,6 +26,12 @@ variable location {
   description = "Location where the node pool should be provisioned."
 }
 
+variable max_pods_per_node {
+  type        = number
+  description = "If provided, override the max number of pods per node in this pool."
+  default     = null
+}
+
 variable node_count {
   type        = number
   description = "Number of nodes to provision in the pool. Required if autoscaling not set"


### PR DESCRIPTION
It's an optional field we don't currently expose. I need it for a sysbox node pool because community edition only supports 16 pods per node.