### PR TITLE
Enable Workload Identity

### DIFF
--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -83,7 +83,7 @@ variable use_new_stackdriver_apis {
 
 variable enable_workload_identity {
   type        = bool
-  default     = false
+  default     = true
   description = "If true, enables k8s<->GCP SA linking in the cluster. See: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."
 }
 


### PR DESCRIPTION
ExternalDNS needs Workload Identity to be on to manage aspects of GCP projects like Cloud DNS zone resource records. Hopefully this is the correct (and only?) place to edit.