### PR TITLE
[DDO-1528] Add initial node count to ignored

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -70,11 +70,11 @@ resource google_container_node_pool pool {
       enable_integrity_monitoring = var.enable_integrity_monitoring
     }
   }
-  # Ignore changes to taints. We set them up at pool creation time, but don't
-  # update them afterwards, because it could trigger node pool recreation and cause
-  # an outage. See
+  # Ignore changes to taints and initial node count. We set them up at pool creation
+  # time, but don't update them afterwards, because it could trigger node pool
+  # recreation and cause an outage. See
   # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#taint
   lifecycle {
-    ignore_changes = [node_config[0].taint]
+    ignore_changes = [node_config[0].taint, initial_node_count]
   }
 }


### PR DESCRIPTION
Adds the initial node count to the ignored fields so that manual node pool count changes in the UI won't force recreation here later. Working at https://github.com/broadinstitute/terraform-ap-deployments/pull/414