### PR TITLE
[DDO-1582] latency-tracking module

### DIFF
--- a/.github/workflows/TerraformTest-latency-tracking.yml
+++ b/.github/workflows/TerraformTest-latency-tracking.yml
@@ -46,3 +46,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Terraform test format check
+      id: test-fmt
+      run: cd test && terraform fmt
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Terraform test init
+      id: test-init
+      run: cd test && terraform init
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Terraform test validate
+      id: test-validate
+      run: cd test && terraform validate
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/TerraformTest-latency-tracking.yml
+++ b/.github/workflows/TerraformTest-latency-tracking.yml
@@ -1,0 +1,48 @@
+name: Terraform Test - latency-tracking module
+
+env:
+  terraform_directory: "terraform-modules/stackdriver/latency-tracking"
+  terraform_version: "1.0.8"
+
+defaults:
+  run:
+    working-directory: "terraform-modules/stackdriver/latency-tracking"
+
+on:
+  pull_request:
+    branches: 
+      - master
+    paths:
+      - terraform-modules/stackdriver/latency-tracking/**
+    
+jobs:
+  terraform_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ env.terraform_version }}
+
+      # Run Terraform fmt (kind of a linter)
+    - name: Terraform format check
+      id: fmt
+      run: terraform fmt
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run Terraform init
+    - name: Terraform init
+      id: init
+      run: terraform init
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run Terraform validate
+    - name: Terraform validate
+      id: validate
+      run: terraform validate
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
+++ b/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
@@ -2,6 +2,26 @@ version: ">= 0.14.0"
 
 formatter: markdown document
 
+content: |-
+  ## Example
+
+  <details>
+  <summary>
+  Click to expand
+  </summary>
+
+  ```hcl
+  {{ include "test/test.tf" }}
+  ```
+
+  </details>
+
+  {{ .Requirements }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
 output:
   file: README.md
   mode: inject

--- a/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
+++ b/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
@@ -5,16 +5,9 @@ formatter: markdown document
 content: |-
   ## Example
 
-  <details>
-  <summary>
-  Click to expand
-  </summary>
-
   ```hcl
   {{ include "test/test.tf" }}
   ```
-
-  </details>
 
   {{ .Requirements }}
 

--- a/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
+++ b/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
@@ -1,0 +1,15 @@
+version: ">= 0.14.0"
+
+formatter: markdown document
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    [//]: # (BEGIN_TF_DOCS)
+    {{ .Content }}
+
+    [//]: # (END_TF_DOCS)
+
+sort:
+  enabled: false

--- a/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
+++ b/terraform-modules/stackdriver/latency-tracking/.terraform-docs.yaml
@@ -7,6 +7,7 @@ output:
   mode: inject
   template: |-
     [//]: # (BEGIN_TF_DOCS)
+    
     {{ .Content }}
 
     [//]: # (END_TF_DOCS)

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -4,16 +4,11 @@ Terraform module enabling per-endpoint latency tracking and alerting based on Go
 
 Note that services without an external HTTPS load balancer--for example, without a standard ingress--cannot be used with this module.
 
-These docs are computed with `terraform-docs .`.
+These docs are computed with `terraform-docs .`
 
 [//]: # (BEGIN_TF_DOCS)
 
 ## Example
-
-<details>
-<summary>
-Click to expand
-</summary>
 
 ```hcl
 module "latency_tracking" {
@@ -65,8 +60,6 @@ module "latency_tracking" {
 }
 
 ```
-
-</details>
 
 ## Requirements
 
@@ -214,6 +207,10 @@ Default: `{}`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url)
+
+Description: The URL of the created dashboard, or null if no endpoints are being tracked.
 
 [//]: # (END_TF_DOCS)

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -1,12 +1,16 @@
 ## Requirements
 
-No requirements.
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 0.15)
+
+- <a name="requirement_google"></a> [google](#requirement\_google) (>=3.65.0)
 
 ## Providers
 
 The following providers are used by this module:
 
-- <a name="provider_google"></a> [google](#provider\_google)
+- <a name="provider_google"></a> [google](#provider\_google) (>=3.65.0)
 
 ## Modules
 
@@ -79,9 +83,13 @@ Default: `null`
 
 ### <a name="input_default_endpoint_config"></a> [default\_endpoint\_config](#input\_default\_endpoint\_config)
 
-Description: Optionally set default alert configurations across all `endpoints`. Any attributes not set  
+Description: Set default configurations across all `endpoints`. Any attributes not set  
 will use the default values.
 
+Required:
+- `fully_qualified_domain_name` must be a full and exact domain name
+
+Optionally set:
 - `alert_threshold_milliseconds` must be a positive whole number, for the latency limit to trigger on.
 - `alert_rolling_window_duration` must be at least 1, for the window to aggregate data.
 - `alert_rolling_window_percentile` must be one of 5, 50, 95, or 99, for the percentile to track.
@@ -93,6 +101,8 @@ Type:
 
 ```hcl
 object({
+    fully_qualified_domain_name     = string
+
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
     alert_rolling_window_duration   = optional(number)
@@ -119,14 +129,18 @@ Default:
 
 Description: Configure each endpoint pattern to track the latency of. Each entry's key is used for naming  
 cloud resources, and the value attributes set how to identify the endpoint and any overrides  
-for the alert or Revere alert label configuration.
+for the domain name, alert, or Revere alert label configuration.
 
 For `endpoint_regex`, recall that the Regex must be escaped through Terraform.
 
 ```hcl
+default_endpoint_config = {
+  fully_qualified_domain_name = "example.com"
+}
+
 endpoints = {
   "status" = {
-    endpoint_regex               = "https://example\\.com/status"
+    endpoint_regex               = "/status"
     enable_alerts                = true
     alert_threshold_milliseconds = 750
   }
@@ -138,6 +152,8 @@ Type:
 ```hcl
 map(object({
     endpoint_regex = string
+
+    fully_qualified_domain_name     = optional(string)
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -139,7 +139,9 @@ Description: Configure each endpoint pattern to track the latency of. Each entry
 cloud resources, and the value attributes set how to identify the endpoint and any overrides  
 for the domain name, alert, or Revere alert label configuration.
 
-For `endpoint_regex`, recall that the Regex must be escaped through Terraform.
+For `endpoint_regex`, recall that the Regex must be escaped through Terraform if you're using complex sequences.
+
+Usage example:
 
 ```hcl
 default_endpoint_config = {

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -69,6 +69,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_google"></a> [google](#requirement\_google) (>=3.65.0)
 
+- <a name="requirement_null"></a> [null](#requirement\_null) (>=3.1.0)
+
 ## Required Inputs
 
 The following input variables are required:
@@ -102,6 +104,17 @@ Description: Whether this module is enabled.
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_resource_creation_delay_seconds"></a> [resource\_creation\_delay\_seconds](#input\_resource\_creation\_delay\_seconds)
+
+Description: Number of seconds to wait between creation of metrics/alerts and alerts/dashboard.
+
+This is a hack! It is necessary because it apparently takes a split second **after** TF believes resources  
+are created before they can be used in other monitoring resources.
+
+Type: `number`
+
+Default: `3`
 
 ### <a name="input_revere_label_configuration"></a> [revere\_label\_configuration](#input\_revere\_label\_configuration)
 

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -1,3 +1,10 @@
+# latency-tracking
+
+Terraform module enabling per-endpoint latency tracking and alerting based on Google external HTTPS load balancers.
+
+These docs are computed with `terraform-docs .`.
+
+[//]: # (BEGIN_TF_DOCS)
 ## Requirements
 
 The following requirements are needed by this module:
@@ -91,7 +98,7 @@ Required:
 
 Optionally set:
 - `alert_threshold_milliseconds` must be a positive whole number, for the latency limit to trigger on.
-- `alert_rolling_window_duration` must be at least 1, for the window to aggregate data.
+- `alert_rolling_window_minutes` must be at least 1, for the window to aggregate data.
 - `alert_rolling_window_percentile` must be one of 5, 50, 95, or 99, for the percentile to track.
 - `alert_retest_window_minutes` must be a non-negative number, for the duration the issue must persist  
 after being triggered by the rolling window before truly sending the alert.
@@ -101,11 +108,11 @@ Type:
 
 ```hcl
 object({
-    fully_qualified_domain_name     = string
+    fully_qualified_domain_name = string
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
-    alert_rolling_window_duration   = optional(number)
+    alert_rolling_window_minutes    = optional(number)
     alert_rolling_window_percentile = optional(number)
     alert_retest_window_minutes     = optional(number)
     alert_notification_channels     = optional(list(string))
@@ -121,7 +128,8 @@ Default:
   "alert_rolling_window_minutes": 5,
   "alert_rolling_window_percentile": 99,
   "alert_threshold_milliseconds": 1000,
-  "enable_alerts": false
+  "enable_alerts": false,
+  "fully_qualified_domain_name": null
 }
 ```
 
@@ -153,7 +161,7 @@ Type:
 map(object({
     endpoint_regex = string
 
-    fully_qualified_domain_name     = optional(string)
+    fully_qualified_domain_name = optional(string)
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
@@ -174,3 +182,5 @@ Default: `{}`
 ## Outputs
 
 No outputs.
+
+[//]: # (END_TF_DOCS)

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -4,6 +4,14 @@ Terraform module enabling per-endpoint latency tracking and alerting based on Go
 
 Note that services without an external HTTPS load balancer--for example, without a standard ingress--cannot be used with this module.
 
+> ### Note for the implementation-curious:
+> This module makes use of the null provider, local-exec provisioner, and manual depends_on relationships to have the applying Terraform
+> executable literally run `sleep` in between applying the three different resource classes here. This is to avoid race conditions
+> on Google's end where a metric or alert can't immediately be referenced from an alert or dashboard.
+>
+> Briefly, the null resources are empty resources that "trigger" exactly once based on changes to endpoints or alerts, that triggering causes
+> local-exec's `sleep`s to run, and manual depends_on relationships prevent other resources from starting until the sleeps are done.
+
 These docs are computed with `terraform-docs .`
 
 [//]: # (BEGIN_TF_DOCS)
@@ -107,7 +115,7 @@ Default: `true`
 
 ### <a name="input_resource_creation_delay_seconds"></a> [resource\_creation\_delay\_seconds](#input\_resource\_creation\_delay\_seconds)
 
-Description: Number of seconds to wait between creation of metrics/alerts and alerts/dashboard.
+Description: Number of seconds to wait between creation of metrics/alerts and alerts/dashboard. Set to 0 to disable.
 
 This is a hack! It is necessary because it apparently takes a split second **after** TF believes resources  
 are created before they can be used in other monitoring resources.

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -21,7 +21,7 @@ These docs are computed with `terraform-docs .`
 ```hcl
 module "latency_tracking" {
   # Adjust trailing ref to select version
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/latency-tracking?ref=DDO-1582-latency-tracking"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/latency-tracking?ref=latency-tracking-1.0.0"
 
   # Assume the standard set of variables and locals available within ap-deployments/terra-monitoring submodules
   enabled        = var.enable && var.allow_latency_tracking

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -7,6 +7,7 @@ Note that services without an external HTTPS load balancer--for example, without
 These docs are computed with `terraform-docs .`.
 
 [//]: # (BEGIN_TF_DOCS)
+
 ## Requirements
 
 The following requirements are needed by this module:

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -1,6 +1,8 @@
 # latency-tracking
 
-Terraform module enabling per-endpoint latency tracking and alerting based on Google external HTTPS load balancers.
+Terraform module enabling per-endpoint latency tracking and alerting based on Google external HTTPS load balancers. 
+
+Note that services without an external HTTPS load balancer--for example, without a standard ingress--cannot be used with this module.
 
 These docs are computed with `terraform-docs .`.
 

--- a/terraform-modules/stackdriver/latency-tracking/README.md
+++ b/terraform-modules/stackdriver/latency-tracking/README.md
@@ -1,0 +1,160 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_google"></a> [google](#provider\_google)
+
+## Modules
+
+No modules.
+
+## Resources
+
+The following resources are used by this module:
+
+- [google_logging_metric.latency_metric](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) (resource)
+- [google_monitoring_alert_policy.latency_alert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) (resource)
+- [google_monitoring_dashboard.latency_dashboard](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) (resource)
+
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_google_project"></a> [google\_project](#input\_google\_project)
+
+Description: Google project containing the load balancers with latency to track.
+
+Type: `string`
+
+### <a name="input_service"></a> [service](#input\_service)
+
+Description: The name of the service to track, used for dashboard/metric/alert names.
+
+Type: `string`
+
+### <a name="input_environment"></a> [environment](#input\_environment)
+
+Description: The environment the service being tracked is in, used for dashboard/metric/alert names.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enabled"></a> [enabled](#input\_enabled)
+
+Description: Whether this module is enabled.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_revere_label_configuration"></a> [revere\_label\_configuration](#input\_revere\_label\_configuration)
+
+Description: Configuration for alert labels allowing Revere to understand alerts.
+
+If not provided, no labels will be added. Only used if alerts are enabled. Can be overridden  
+per-endpoint in `endpoints`.
+
+More information is available
+[here](https://github.com/broadinstitute/revere/blob/main/docs/gcp_alert_policy_labels.md).
+
+Type:
+
+```hcl
+object({
+    enable_revere_service_labels = bool
+    revere_service_name          = string
+    revere_service_environment   = string
+    revere_alert_type_latency    = string
+  })
+```
+
+Default: `null`
+
+### <a name="input_default_endpoint_config"></a> [default\_endpoint\_config](#input\_default\_endpoint\_config)
+
+Description: Optionally set default alert configurations across all `endpoints`. Any attributes not set  
+will use the default values.
+
+- `alert_threshold_milliseconds` must be a positive whole number, for the latency limit to trigger on.
+- `alert_rolling_window_duration` must be at least 1, for the window to aggregate data.
+- `alert_rolling_window_percentile` must be one of 5, 50, 95, or 99, for the percentile to track.
+- `alert_retest_window_minutes` must be a non-negative number, for the duration the issue must persist  
+after being triggered by the rolling window before truly sending the alert.
+- `alert_notification_channels` is a list of any pre-existing channel IDs in the project to notify.
+
+Type:
+
+```hcl
+object({
+    enable_alerts                   = optional(bool)
+    alert_threshold_milliseconds    = optional(number)
+    alert_rolling_window_duration   = optional(number)
+    alert_rolling_window_percentile = optional(number)
+    alert_retest_window_minutes     = optional(number)
+    alert_notification_channels     = optional(list(string))
+  })
+```
+
+Default:
+
+```json
+{
+  "alert_notification_channels": [],
+  "alert_retest_window_minutes": 0,
+  "alert_rolling_window_minutes": 5,
+  "alert_rolling_window_percentile": 99,
+  "alert_threshold_milliseconds": 1000,
+  "enable_alerts": false
+}
+```
+
+### <a name="input_endpoints"></a> [endpoints](#input\_endpoints)
+
+Description: Configure each endpoint pattern to track the latency of. Each entry's key is used for naming  
+cloud resources, and the value attributes set how to identify the endpoint and any overrides  
+for the alert or Revere alert label configuration.
+
+For `endpoint_regex`, recall that the Regex must be escaped through Terraform.
+
+```hcl
+endpoints = {
+  "status" = {
+    endpoint_regex               = "https://example\\.com/status"
+    enable_alerts                = true
+    alert_threshold_milliseconds = 750
+  }
+}
+```
+
+Type:
+
+```hcl
+map(object({
+    endpoint_regex = string
+
+    enable_alerts                   = optional(bool)
+    alert_threshold_milliseconds    = optional(number)
+    alert_rolling_window_minutes    = optional(number)
+    alert_rolling_window_percentile = optional(number)
+    alert_retest_window_minutes     = optional(number)
+    alert_notification_channels     = optional(list(string))
+
+    enable_revere_service_labels = optional(bool)
+    revere_service_name          = optional(string)
+    revere_service_environment   = optional(string)
+    revere_alert_type_latency    = optional(string)
+  }))
+```
+
+Default: `{}`
+
+## Outputs
+
+No outputs.

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -48,6 +48,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
 }
 
 resource "null_resource" "pause_after_alert_change" {
+  count = length(local.final_computed_endpoints) > 0 ? 1 : 0
   triggers = {
     metric_ids = join(",", values(google_monitoring_alert_policy.latency_alert)[*].id)
   }

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -21,10 +21,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
   conditions {
     display_name = "${var.service}-${var.environment}-${each.key}-endpoint-latency-alert-condition"
     condition_threshold {
-      filter = <<-EOT
-        resource.type = "l7_lb_rule" AND
-        metric.type = "logging.googleapis.com/user/${google_logging_metric.latency_metric[each.key].name}
-      EOT
+      filter = "resource.type = \"l7_lb_rule\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.latency_metric[each.key].name}\""
       aggregations {
         alignment_period     = "${floor(each.value.alert_rolling_window_minutes * 60)}s"
         cross_series_reducer = "REDUCE_NONE"

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -48,7 +48,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
 }
 
 resource "null_resource" "pause_after_alert_change" {
-  count = length(local.final_computed_endpoints) > 0 ? 1 : 0
+  count = length(local.final_computed_endpoints) > 0 && var.resource_creation_delay_seconds > 0 ? 1 : 0
   triggers = {
     metric_ids = join(",", values(google_monitoring_alert_policy.latency_alert)[*].id)
   }

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -4,7 +4,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
     if config.enable_alerts
   }
 
-  depends_on = ["null_resource.pause_after_metric_change"]
+  depends_on = [null_resource.pause_after_metric_change]
 
   project      = var.google_project
   display_name = "${var.service}-${var.environment}-${each.key}-endpoint-latency-alert"
@@ -49,7 +49,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
 
 resource "null_resource" "pause_after_alert_change" {
   triggers = {
-    metric_ids = join(",", google_monitoring_alert_policy.latency_alert.*.id)
+    metric_ids = join(",", google_monitoring_alert_policy.latency_alert[*].id)
   }
   provisioner "local-exec" {
     command    = "sleep ${var.resource_creation_delay_seconds}"

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -49,7 +49,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
 
 resource "null_resource" "pause_after_alert_change" {
   triggers = {
-    metric_ids = join(",", google_monitoring_alert_policy.latency_alert[*].id)
+    metric_ids = join(",", values(google_monitoring_alert_policy.latency_alert)[*].id)
   }
   provisioner "local-exec" {
     command    = "sleep ${var.resource_creation_delay_seconds}"

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -26,7 +26,6 @@ resource "google_monitoring_alert_policy" "latency_alert" {
       filter = "resource.type = \"l7_lb_rule\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.latency_metric[each.key].name}\""
       aggregations {
         alignment_period     = "${floor(each.value.alert_rolling_window_minutes * 60)}s"
-        cross_series_reducer = "REDUCE_NONE"
         per_series_aligner   = "ALIGN_PERCENTILE_${each.value.alert_rolling_window_percentile}"
       }
       comparison = "COMPARISON_GT"

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -1,0 +1,49 @@
+resource "google_monitoring_alert_policy" "latency_alert" {
+  for_each = {
+    for name, config in local.merged_endpoints : name => config
+    if config.enable_alerts
+  }
+
+  project      = var.google_project
+  display_name = "${var.service}-${var.environment}-${each.key}-endpoint-latency-alert"
+  combiner     = "OR"
+
+  documentation {
+    content   = <<-EOT
+      Latency for the *${var.service} ${each.key}* endpoint *in ${var.environment}* matched by
+      `${each.value.endpoint_regex}` exceeded ${each.value.alert_threshold_milliseconds}ms
+      for the ${each.value.alert_rolling_window_percentile}th percentile over
+      ${each.value.alert_rolling_window_minutes} minutes
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "${var.service}-${var.environment}-${each.key}-endpoint-latency-alert-condition"
+    condition_threshold {
+      filter = <<-EOT
+        resource.type = "l7_lb_rule" AND
+        metric.type = "logging.googleapis.com/user/${google_logging_metric.latency_metric[each.key].name}
+      EOT
+      aggregations {
+        alignment_period     = "${floor(each.value.alert_rolling_window_minutes * 60)}s"
+        cross_series_reducer = "REDUCE_NONE"
+        per_series_aligner   = "ALIGN_PERCENTILE_${each.value.alert_rolling_window_percentile}"
+      }
+      comparison = "COMPARISON_GT"
+      duration   = "${floor(each.value.alert_retest_window_minutes * 60)}s"
+      trigger {
+        count = 1
+      }
+      threshold_value = each.value.alert_threshold_milliseconds / 1000
+    }
+  }
+
+  notification_channels = each.value.alert_notification_channels
+
+  user_labels = each.value.enable_revere_service_labels ? {
+    revere-service-name        = each.value.revere_service_name
+    revere-service-environment = each.value.revere_service_environment
+    revere-alert-type          = each.value.revere_alert_type_latency
+  } : null
+}

--- a/terraform-modules/stackdriver/latency-tracking/alert.tf
+++ b/terraform-modules/stackdriver/latency-tracking/alert.tf
@@ -1,6 +1,6 @@
 resource "google_monitoring_alert_policy" "latency_alert" {
   for_each = {
-    for name, config in local.merged_endpoints : name => config
+    for name, config in local.final_computed_endpoints : name => config
     if config.enable_alerts
   }
 
@@ -11,7 +11,7 @@ resource "google_monitoring_alert_policy" "latency_alert" {
   documentation {
     content   = <<-EOT
       Latency for the *${var.service} ${each.key}* endpoint *in ${var.environment}* matched by
-      `${each.value.endpoint_regex}` exceeded ${each.value.alert_threshold_milliseconds}ms
+      `${each.value.computed_regex}` exceeded ${each.value.alert_threshold_milliseconds}ms
       for the ${each.value.alert_rolling_window_percentile}th percentile over
       ${each.value.alert_rolling_window_minutes} minutes
     EOT

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -25,7 +25,6 @@ locals {
               "plotType": "HEATMAP",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "apiSource": "DEFAULT_CLOUD",
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
@@ -96,7 +95,7 @@ dashboard = <<EOT
   "category": "CUSTOM",
   "displayName": "${var.service}-${var.environment}-endpoint-latency",
   "gridLayout": {
-    "columns": 2,
+    "columns": "2",
     "widgets": [
 ${join(",\n", local.widgets)}
     ]

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -4,7 +4,7 @@ locals {
   # - We assemble a list of lexicographically sorted endpoint names, putting the ones with alerts first
   ordered_endpoints = concat(
     sort([for name, config in local.final_computed_endpoints : name if config.enable_alerts]),
-    sort([for name, config in local.final_computed_endpoints : name if ! config.enable_alerts])
+    sort([for name, config in local.final_computed_endpoints : name if !config.enable_alerts])
   )
   # Second, we assemble a heatmap widget for every endpoint.
   # - This is the graph that appears regardless of whether alerting is enabled
@@ -75,7 +75,7 @@ EOT
 EOT
 }
 
-# Fourth, we finally assemble a list of all widgets,
+# Fourth, we finally assemble a list of all widgets
 # - Position info is derived from order
 # - We leave off the trailing comma so it can be added as the separator
 #   (so we don't have an actual trailing comma in the JSON)

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -1,7 +1,6 @@
 locals {
   # First, we contend with dashboard's indexing.
   # - We have an unordered map of endpoints
-  # - Terraform only allows indexes to be derived from lists (no counted loops still, but `index` works)
   # - We assemble a list of lexicographically sorted endpoint names, putting the ones with alerts first
   ordered_endpoints = concat(
     sort([for name, config in local.final_computed_endpoints : name if config.enable_alerts]),
@@ -15,7 +14,7 @@ locals {
   #   where you can poke around the data
   heatmap_widgets = {
     for name, config in local.final_computed_endpoints : name => <<EOT
-        "title": "Latency: ${var.service} ${name} in ${var.environment}",
+        "title": "Latency (exponential view): ${var.service} ${name} in ${var.environment}",
         "xyChart": {
           "chartOptions": {
             "mode": "COLOR"

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -29,7 +29,6 @@ locals {
                   "aggregation": {
                     "alignmentPeriod": "60s",
                     "crossSeriesReducer": "REDUCE_SUM",
-                    "groupByFields": [],
                     "perSeriesAligner": "ALIGN_DELTA"
                   },
                 "filter": "metric.type=\"logging.googleapis.com/user/${google_logging_metric.latency_metric[name].name}\" AND resource.type=\"l7_lb_rule\""

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -1,0 +1,128 @@
+locals {
+  # First, we contend with dashboard's indexing.
+  # - We have an unordered map of endpoints
+  # - Terraform only allows indexes to be derived from lists (no counted loops still, but `index` works)
+  # - We assemble a list of lexicographically sorted endpoint names, putting the ones with alerts first
+  ordered_endpoints = concat(
+    sort([for name, config in local.merged_endpoints : name if config.enable_alerts]),
+    sort([for name, config in local.merged_endpoints : name if ! config.enable_alerts])
+  )
+  # Second, we assemble a heatmap widget for every endpoint.
+  # - This is the graph that appears regardless of whether alerting is enabled
+  # - If alerting is enabled, we add the threshold as a line
+  # - We associate the JSON snippet to the endpoint name so we can grab it later
+  # - Not a ton of configuration here because there's a button to open it up in the explorer
+  #   where you can poke around the data
+  heatmap_widgets = {
+    for name, config in local.merged_endpoints : name => <<EOT
+          "title": "Latency: ${var.service} ${name} in ${var.environment}",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"logging.googleapis.com/user/${google_logging_metric.latency_metric[name].name}\" AND resource.type=\"l7_lb_rule\""
+                  }
+                }
+              }
+            ],
+            ${config.enable_alerts ? <<EOTnested
+            "thresholds": [
+              {
+                "label": "alert threshold",
+                "targetAxis": "Y1",
+                "value": ${config.alert_threshold_milliseconds / 1000}
+              }
+            ],
+EOTnested
+  : "\"thresholds\": [],"}
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+EOT
+}
+
+# Third, we assemble an alert view widget or a text view widget for each endpoint
+# - If the endpoint has alerting enabled, grab a graph showing that specific alert condition
+# - If not, add a text widget noting that to avoid confusion
+alert_widgets = {
+  for name, config in local.merged_endpoints : name => config.enable_alerts ? <<EOT
+          "alertChart": {
+            "name": "${google_monitoring_alert_policy.latency_alert[name].name}"
+          }
+EOT
+  : <<EOT
+          "text": {
+            "content": "If you'd like to add an alert targeting this endpoint (`${config.endpoint_regex}`), you can do so wherever ${var.service}-${var.environment}'s [latency-tracking](https://github.com/broadinstitute/terraform-shared/tree/master/terraform-modules/stackdriver/latency-tracking) module is instantiated.",
+            "format": "MARKDOWN"
+          },
+          "title": "No latency alert configured for ${var.service} ${name} in ${var.environment}"
+EOT
+}
+
+# Fourth, we finally assemble a list of all tiles, each containing a widget and position info
+# - The order of the tiles in the JSON technically doesn't matter, but the xPos and yPos do
+# - We iterate over the ordered list to keep the execution order stable
+# - We still have to call `index` to get the actual numerical index
+# - We leave off the trailing comma so it can be added as the separator
+#   (so we don't have an actual trailing comma in the JSON)
+tiles = [
+  for name in local.ordered_endpoints : <<EOT
+      {
+        "height": 1,
+        "widget": {
+${local.heatmap_widgets[name]}
+        },
+        "width": 1,
+        "xPos": 0,
+        "yPos": ${index(local.ordered_endpoints, name)}
+      },
+      {
+        "height": 1,
+        "widget": {
+${local.alert_widgets[name]}
+        },
+        "width": 1,
+        "xPos": 1,
+        "yPos": ${index(local.ordered_endpoints, name)}
+      }
+EOT
+]
+
+# Last, we can join the list of tiles and add the surrounding JSON
+dashboard = <<EOT
+{
+  "category": "CUSTOM",
+  "displayName": "${var.service}-${var.environment}-endpoint-latency",
+  "mosaicLayout": {
+    "columns": 2,
+    "tiles": [
+${join(",\n", local.tiles)}
+    ]
+  }
+}
+EOT
+}
+
+resource "google_monitoring_dashboard" "latency_dashboard" {
+  count = length(local.merged_endpoints) > 0 ? 1 : 0
+
+  project        = var.google_project
+  dashboard_json = local.dashboard
+}

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -91,7 +91,6 @@ EOT
 # Last, we can join the list of widgets and add the surrounding JSON
 dashboard = <<EOT
 {
-  "category": "CUSTOM",
   "displayName": "${var.service}-${var.environment}-endpoint-latency",
   "gridLayout": {
     "columns": "2",

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -108,6 +108,11 @@ EOT
 resource "google_monitoring_dashboard" "latency_dashboard" {
   count = length(local.final_computed_endpoints) > 0 ? 1 : 0
 
+  depends_on = [
+    "null_resource.pause_after_metric_change",
+    "null_resource.pause_after_alert_change"
+  ]
+
   project        = var.google_project
   dashboard_json = local.dashboard
 }

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -109,8 +109,8 @@ resource "google_monitoring_dashboard" "latency_dashboard" {
   count = length(local.final_computed_endpoints) > 0 ? 1 : 0
 
   depends_on = [
-    "null_resource.pause_after_metric_change",
-    "null_resource.pause_after_alert_change"
+    null_resource.pause_after_metric_change,
+    null_resource.pause_after_alert_change
   ]
 
   project        = var.google_project

--- a/terraform-modules/stackdriver/latency-tracking/dashboard.tf
+++ b/terraform-modules/stackdriver/latency-tracking/dashboard.tf
@@ -69,7 +69,7 @@ alert_widgets = {
 EOT
   : <<EOT
           "text": {
-            "content": "If you'd like to add an alert targeting this endpoint (`${config.computed_regex}`), you can do so wherever ${var.service}-${var.environment}'s [latency-tracking](https://github.com/broadinstitute/terraform-shared/tree/master/terraform-modules/stackdriver/latency-tracking) module is instantiated.",
+            "content": "If you'd like to add an alert targeting this endpoint (`${replace(config.computed_regex, "\\", "\\\\")}`), you can do so wherever ${var.service}-${var.environment}'s [latency-tracking](https://github.com/broadinstitute/terraform-shared/tree/master/terraform-modules/stackdriver/latency-tracking) module is instantiated.",
             "format": "MARKDOWN"
           },
           "title": "No latency alert configured for ${var.service} ${name} in ${var.environment}"

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -31,6 +31,7 @@ resource "google_logging_metric" "latency_metric" {
 }
 
 resource "null_resource" "pause_after_metric_change" {
+  count = length(local.final_computed_endpoints) > 0 ? 1 : 0
   triggers = {
     metric_ids = join(",", values(google_logging_metric.latency_metric)[*].id)
   }

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -1,5 +1,5 @@
 resource "google_logging_metric" "latency_metric" {
-  for_each = local.merged_endpoints
+  for_each = local.final_computed_endpoints
 
   project = var.google_project
   name = "${var.service}-${var.environment}-${var.environment}-${each.key}-endpoint-latency"
@@ -7,7 +7,7 @@ resource "google_logging_metric" "latency_metric" {
   filter = <<-EOT
     resource.type="http_load_balancer" AND
     resource.labels.project_id="${var.google_project}" AND
-    httpRequest.requestUrl=~"${each.value.endpoint_regex}"
+    httpRequest.requestUrl=~"${each.value.computed_regex}"
   EOT
 
   metric_descriptor {

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -31,7 +31,7 @@ resource "google_logging_metric" "latency_metric" {
 }
 
 resource "null_resource" "pause_after_metric_change" {
-  count = length(local.final_computed_endpoints) > 0 ? 1 : 0
+  count = length(local.final_computed_endpoints) > 0 && var.resource_creation_delay_seconds > 0 ? 1 : 0
   triggers = {
     metric_ids = join(",", values(google_logging_metric.latency_metric)[*].id)
   }

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -29,3 +29,13 @@ resource "google_logging_metric" "latency_metric" {
     }
   }
 }
+
+resource "null_resource" "pause_after_metric_change" {
+  triggers = {
+    metric_ids = join(",", google_logging_metric.latency_metric.*.id)
+  }
+  provisioner "local-exec" {
+    command    = "sleep ${var.resource_creation_delay_seconds}"
+    on_failure = continue
+  }
+}

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -1,19 +1,19 @@
 resource "google_logging_metric" "latency_metric" {
   for_each = local.final_computed_endpoints
 
-  project = var.google_project
-  name = "${var.service}-${var.environment}-${var.environment}-${each.key}-endpoint-latency"
+  project     = var.google_project
+  name        = "${var.service}-${var.environment}-${var.environment}-${each.key}-endpoint-latency"
   description = "Latency of ${var.service}'s ${each.key} endpoint in ${var.environment}"
-  filter = <<-EOT
+  filter      = <<-EOT
     resource.type="http_load_balancer" AND
     resource.labels.project_id="${var.google_project}" AND
     httpRequest.requestUrl=~"${each.value.computed_regex}"
   EOT
 
   metric_descriptor {
-    metric_kind = "DELTA"
-    value_type = "DISTRIBUTION"
-    unit = "s"
+    metric_kind  = "DELTA"
+    value_type   = "DISTRIBUTION"
+    unit         = "s"
     display_name = "Latency for ${var.service} ${each.key} in ${var.environment}"
   }
 
@@ -23,8 +23,8 @@ resource "google_logging_metric" "latency_metric" {
   bucket_options {
     exponential_buckets {
       num_finite_buckets = 64
-      growth_factor = 2
-      scale = 0.01
+      growth_factor      = 2
+      scale              = 0.01
     }
   }
 }

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -1,0 +1,30 @@
+resource "google_logging_metric" "latency_metric" {
+  for_each = local.merged_endpoints
+
+  project = var.google_project
+  name = "${var.service}-${var.environment}-${var.environment}-${each.key}-endpoint-latency"
+  description = "Latency of ${var.service}'s ${each.key} endpoint in ${var.environment}"
+  filter = <<-EOT
+    resource.type="http_load_balancer" AND
+    resource.labels.project_id="${var.google_project}" AND
+    httpRequest.requestUrl=~"${each.value.endpoint_regex}"
+  EOT
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type = "DISTRIBUTION"
+    unit = "s"
+    display_name = "Latency for ${var.service} ${each.key} in ${var.environment}"
+  }
+
+  value_extractor = "REGEXP_EXTRACT(httpRequest.latency, \"([0-9.]+)\")"
+
+  # Only used for histogram view, required for DISTRIBUTION type, these are Google's defaults
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 64
+      growth_factor = 2
+      scale = 0.01
+    }
+  }
+}

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -32,7 +32,7 @@ resource "google_logging_metric" "latency_metric" {
 
 resource "null_resource" "pause_after_metric_change" {
   triggers = {
-    metric_ids = join(",", google_logging_metric.latency_metric[*].id)
+    metric_ids = join(",", values(google_logging_metric.latency_metric)[*].id)
   }
   provisioner "local-exec" {
     command    = "sleep ${var.resource_creation_delay_seconds}"

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -32,7 +32,7 @@ resource "google_logging_metric" "latency_metric" {
 
 resource "null_resource" "pause_after_metric_change" {
   triggers = {
-    metric_ids = join(",", google_logging_metric.latency_metric.*.id)
+    metric_ids = join(",", google_logging_metric.latency_metric[*].id)
   }
   provisioner "local-exec" {
     command    = "sleep ${var.resource_creation_delay_seconds}"

--- a/terraform-modules/stackdriver/latency-tracking/metric.tf
+++ b/terraform-modules/stackdriver/latency-tracking/metric.tf
@@ -2,11 +2,12 @@ resource "google_logging_metric" "latency_metric" {
   for_each = local.final_computed_endpoints
 
   project     = var.google_project
-  name        = "${var.service}-${var.environment}-${var.environment}-${each.key}-endpoint-latency"
+  name        = "${var.service}-${var.environment}-${each.key}-endpoint-latency"
   description = "Latency of ${var.service}'s ${each.key} endpoint in ${var.environment}"
   filter      = <<-EOT
     resource.type="http_load_balancer" AND
     resource.labels.project_id="${var.google_project}" AND
+    ${each.value.request_method != null ? "httpRequest.requestMethod=\"${each.value.request_method}\" AND" : ""}
     httpRequest.requestUrl=~"${each.value.computed_regex}"
   EOT
 

--- a/terraform-modules/stackdriver/latency-tracking/outputs.tf
+++ b/terraform-modules/stackdriver/latency-tracking/outputs.tf
@@ -1,0 +1,8 @@
+output "dashboard_url" {
+  value = (
+    length(local.final_computed_endpoints) > 0
+    ? "https://console.cloud.google.com/monitoring/dashboards/builder/${element(split("/", google_monitoring_dashboard[0].id), 3)}?project=${var.google_project}"
+    : null
+  )
+  description = "The URL of the created dashboard, or null if no endpoints are being tracked."
+}

--- a/terraform-modules/stackdriver/latency-tracking/outputs.tf
+++ b/terraform-modules/stackdriver/latency-tracking/outputs.tf
@@ -1,7 +1,7 @@
 output "dashboard_url" {
   value = (
     length(local.final_computed_endpoints) > 0
-    ? "https://console.cloud.google.com/monitoring/dashboards/builder/${element(split("/", google_monitoring_dashboard[0].id), 3)}?project=${var.google_project}"
+    ? "https://console.cloud.google.com/monitoring/dashboards/builder/${element(split("/", google_monitoring_dashboard.latency_dashboard[0].id), 3)}?project=${var.google_project}"
     : null
   )
   description = "The URL of the created dashboard, or null if no endpoints are being tracked."

--- a/terraform-modules/stackdriver/latency-tracking/terraform.tf
+++ b/terraform-modules/stackdriver/latency-tracking/terraform.tf
@@ -7,5 +7,9 @@ terraform {
       source  = "hashicorp/google"
       version = ">=3.65.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">=3.1.0"
+    }
   }
 }

--- a/terraform-modules/stackdriver/latency-tracking/terraform.tf
+++ b/terraform-modules/stackdriver/latency-tracking/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.15"
+  experiments      = [module_variable_optional_attrs]
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=3.65.0"
+    }
+  }
+}

--- a/terraform-modules/stackdriver/latency-tracking/test/.gitignore
+++ b/terraform-modules/stackdriver/latency-tracking/test/.gitignore
@@ -1,0 +1,5 @@
+.terraform/*
+.terraform.d/*
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock.hcl

--- a/terraform-modules/stackdriver/latency-tracking/test/test.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test.tf
@@ -1,0 +1,47 @@
+module "latency_tracking" {
+  # Adjust trailing ref to select version
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/latency-tracking?ref=DDO-1582-latency-tracking"
+
+  # Assume the standard set of variables and locals available within ap-deployments/terra-monitoring submodules
+  enabled        = var.enable && var.allow_latency_tracking
+  google_project = var.google_project
+  service        = "example-service"
+  environment    = terraform.workspace
+
+  # Revere labels usually configured by parent module, leave as-is
+  revere_label_configuration = var.revere_label_configuration
+
+  # See docs for options and defaults, all can be overridden per-endpoint
+  default_endpoint_config = {
+    fully_qualified_domain_name = local.fqdn
+    alert_notification_channels = concat(local.critical_notification_channels, local.non_critical_notification_channels)
+    enable_alerts               = true
+  }
+
+  endpoints = {
+    status = {
+      # Only required field is `endpoint_regex`
+      endpoint_regex = "/status"
+    },
+    version = {
+      endpoint_regex = "/version"
+      # Alerts can be enabled/disabled per-endpoint
+      enable_alerts = false
+    },
+    get-person = {
+      # Regex supported, but must be escaped through Terraform
+      endpoint_regex = "/api/v1/person/\\d+"
+      # `request_method` can optionally narrow the filter
+      request_method = "GET"
+    },
+    post-person = {
+      endpoint_regex = "/api/v1/person/\\d+"
+      request_method = "POST"
+      # Optional alert customization can be done in `default_endpoint_config` or here per-endpoint
+      alert_threshold_milliseconds    = 1500
+      alert_rolling_window_minutes    = 10
+      alert_rolling_window_percentile = 99
+      alert_retest_window_minutes     = 10
+    }
+  }
+}

--- a/terraform-modules/stackdriver/latency-tracking/test/test.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test.tf
@@ -1,6 +1,6 @@
 module "latency_tracking" {
   # Adjust trailing ref to select version
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/latency-tracking?ref=DDO-1582-latency-tracking"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/latency-tracking?ref=latency-tracking-1.0.0"
 
   # Assume the standard set of variables and locals available within ap-deployments/terra-monitoring submodules
   enabled        = var.enable && var.allow_latency_tracking

--- a/terraform-modules/stackdriver/latency-tracking/test/test_providers.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_providers.tf
@@ -1,0 +1,5 @@
+# Does not need auth for validation
+provider "google" {
+  project = "broad-dsde-dev"
+  region  = "us-central1"
+}

--- a/terraform-modules/stackdriver/latency-tracking/test/test_providers.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_providers.tf
@@ -1,3 +1,5 @@
+# This file just contains stubs, necessary for test.tf to pass validation
+
 # Does not need auth for validation
 provider "google" {
   project = "broad-dsde-dev"

--- a/terraform-modules/stackdriver/latency-tracking/test/test_terraform.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.15"
+  experiments      = [module_variable_optional_attrs]
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=3.65.0"
+    }
+  }
+}

--- a/terraform-modules/stackdriver/latency-tracking/test/test_terraform.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_terraform.tf
@@ -1,3 +1,5 @@
+# This file just contains stubs, necessary for test.tf to pass validation
+
 terraform {
   required_version = ">= 0.15"
   experiments      = [module_variable_optional_attrs]

--- a/terraform-modules/stackdriver/latency-tracking/test/test_variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_variables.tf
@@ -1,0 +1,26 @@
+variable "enable" {
+  default = true
+}
+
+variable "allow_latency_tracking" {
+  default = true
+}
+
+variable "google_project" {
+  default = "broad-dsde-dev"
+}
+
+variable "revere_label_configuration" {
+  default = {
+    enable_revere_service_labels = true
+    revere_service_name          = "example-service"
+    revere_service_environment   = "dev"
+    revere_alert_type_latency    = "degraded-performance"
+  }
+}
+
+locals {
+  fqdn                               = "example.com"
+  critical_notification_channels     = ["some-channel"]
+  non_critical_notification_channels = ["some-other-channel"]
+}

--- a/terraform-modules/stackdriver/latency-tracking/test/test_variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/test/test_variables.tf
@@ -1,3 +1,5 @@
+# This file just contains stubs, necessary for test.tf to pass validation
+
 variable "enable" {
   default = true
 }

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -125,7 +125,9 @@ variable "endpoints" {
     cloud resources, and the value attributes set how to identify the endpoint and any overrides
     for the domain name, alert, or Revere alert label configuration.
 
-    For `endpoint_regex`, recall that the Regex must be escaped through Terraform.
+    For `endpoint_regex`, recall that the Regex must be escaped through Terraform if you're using complex sequences.
+
+    Usage example:
 
     ```hcl
     default_endpoint_config = {

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -56,7 +56,7 @@ variable "default_endpoint_config" {
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
-    alert_rolling_window_duration   = optional(number)
+    alert_rolling_window_minutes    = optional(number)
     alert_rolling_window_percentile = optional(number)
     alert_retest_window_minutes     = optional(number)
     alert_notification_channels     = optional(list(string))
@@ -70,7 +70,7 @@ variable "default_endpoint_config" {
 
     Optionally set:
     - `alert_threshold_milliseconds` must be a positive whole number, for the latency limit to trigger on.
-    - `alert_rolling_window_duration` must be at least 1, for the window to aggregate data.
+    - `alert_rolling_window_minutes` must be at least 1, for the window to aggregate data.
     - `alert_rolling_window_percentile` must be one of 5, 50, 95, or 99, for the percentile to track.
     - `alert_retest_window_minutes` must be a non-negative number, for the duration the issue must persist
     after being triggered by the rolling window before truly sending the alert.

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -78,7 +78,7 @@ variable "default_endpoint_config" {
   EOT
   # Note defaults here so it appears in documentation
   default = {
-    fully_qualified_domain_name     = null
+    fully_qualified_domain_name     = ""
     enable_alerts                   = false
     alert_threshold_milliseconds    = 1000
     alert_rolling_window_minutes    = 5

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -1,0 +1,141 @@
+#
+# General Vars
+#
+
+variable "enabled" {
+  type        = bool
+  description = "Whether this module is enabled."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "Google project containing the load balancers with latency to track."
+}
+
+variable "service" {
+  type        = string
+  description = "The name of the service to track, used for dashboard/metric/alert names."
+}
+
+variable "environment" {
+  type = string
+  description = "The environment the service being tracked is in, used for dashboard/metric/alert names."
+}
+
+#
+# Revere (https://github.com/broadinstitute/revere)
+#
+
+variable "revere_label_configuration" {
+  type = object({
+    enable_revere_service_labels = bool
+    revere_service_name          = string
+    revere_service_environment   = string
+    revere_alert_type_latency    = string
+  })
+  default     = null
+  description = <<-EOT
+    Configuration for alert labels allowing Revere to understand alerts.
+
+    If not provided, no labels will be added. Only used if alerts are enabled. Can be overridden
+    per-endpoint in `endpoints`.
+
+    More information is available
+    [here](https://github.com/broadinstitute/revere/blob/main/docs/gcp_alert_policy_labels.md).
+  EOT
+}
+
+#
+# Endpoints
+#
+
+variable "default_endpoint_config" {
+  type = object({
+    enable_alerts                   = optional(bool)
+    alert_threshold_milliseconds    = optional(number)
+    alert_rolling_window_duration   = optional(number)
+    alert_rolling_window_percentile = optional(number)
+    alert_retest_window_minutes     = optional(number)
+    alert_notification_channels     = optional(list(string))
+  })
+  description = <<-EOT
+    Optionally set default alert configurations across all `endpoints`. Any attributes not set
+    will use the default values.
+
+    - `alert_threshold_milliseconds` must be a positive whole number, for the latency limit to trigger on.
+    - `alert_rolling_window_duration` must be at least 1, for the window to aggregate data.
+    - `alert_rolling_window_percentile` must be one of 5, 50, 95, or 99, for the percentile to track.
+    - `alert_retest_window_minutes` must be a non-negative number, for the duration the issue must persist
+    after being triggered by the rolling window before truly sending the alert.
+    - `alert_notification_channels` is a list of any pre-existing channel IDs in the project to notify.
+  EOT
+  # Note defaults here so it appears in documentation
+  default = {
+    enable_alerts                   = false
+    alert_threshold_milliseconds    = 1000
+    alert_rolling_window_minutes    = 5
+    alert_rolling_window_percentile = 99
+    alert_retest_window_minutes     = 0
+    alert_notification_channels     = []
+  }
+}
+
+locals {
+  # Merge defaults here in case only some values passed via default_endpoint_config
+  baseline_endpoint_config = defaults(var.default_endpoint_config, {
+    enable_alerts                   = false
+    alert_threshold_milliseconds    = 1000
+    alert_rolling_window_minutes    = 5
+    alert_rolling_window_percentile = 99
+    alert_retest_window_minutes     = 0
+    alert_notification_channels     = []
+  })
+}
+
+variable "endpoints" {
+  type = map(object({
+    endpoint_regex = string
+
+    enable_alerts                   = optional(bool)
+    alert_threshold_milliseconds    = optional(number)
+    alert_rolling_window_minutes    = optional(number)
+    alert_rolling_window_percentile = optional(number)
+    alert_retest_window_minutes     = optional(number)
+    alert_notification_channels     = optional(list(string))
+
+    enable_revere_service_labels = optional(bool)
+    revere_service_name          = optional(string)
+    revere_service_environment   = optional(string)
+    revere_alert_type_latency    = optional(string)
+  }))
+  description = <<-EOT
+    Configure each endpoint pattern to track the latency of. Each entry's key is used for naming
+    cloud resources, and the value attributes set how to identify the endpoint and any overrides
+    for the alert or Revere alert label configuration.
+
+    For `endpoint_regex`, recall that the Regex must be escaped through Terraform.
+
+    ```hcl
+    endpoints = {
+      "status" = {
+        endpoint_regex               = "https://example\\.com/status"
+        enable_alerts                = true
+        alert_threshold_milliseconds = 750
+      }
+    }
+    ```
+  EOT
+  default = {}
+}
+
+locals {
+  # Disabled is equivalent to zero endpoints specified
+  merged_endpoints = var.enabled ? {
+    for name, config in var.endpoints : name => merge(
+      (var.revere_label_configuration == null ? {} : var.revere_label_configuration),
+      local.baseline_endpoint_config,
+      config
+    )
+  } : {}
+}

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -23,6 +23,17 @@ variable "environment" {
   description = "The environment the service being tracked is in, used for dashboard/metric/alert names."
 }
 
+variable "resource_creation_delay_seconds" {
+  type        = number
+  default     = 3
+  description = <<-EOT
+    Number of seconds to wait between creation of metrics/alerts and alerts/dashboard.
+
+    This is a hack! It is necessary because it apparently takes a split second **after** TF believes resources
+    are created before they can be used in other monitoring resources.
+  EOT
+}
+
 #
 # Revere (https://github.com/broadinstitute/revere)
 #

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -27,7 +27,7 @@ variable "resource_creation_delay_seconds" {
   type        = number
   default     = 3
   description = <<-EOT
-    Number of seconds to wait between creation of metrics/alerts and alerts/dashboard.
+    Number of seconds to wait between creation of metrics/alerts and alerts/dashboard. Set to 0 to disable.
 
     This is a hack! It is necessary because it apparently takes a split second **after** TF believes resources
     are created before they can be used in other monitoring resources.

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -19,7 +19,7 @@ variable "service" {
 }
 
 variable "environment" {
-  type = string
+  type        = string
   description = "The environment the service being tracked is in, used for dashboard/metric/alert names."
 }
 
@@ -52,7 +52,7 @@ variable "revere_label_configuration" {
 
 variable "default_endpoint_config" {
   type = object({
-    fully_qualified_domain_name     = string
+    fully_qualified_domain_name = string
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
@@ -78,7 +78,7 @@ variable "default_endpoint_config" {
   EOT
   # Note defaults here so it appears in documentation
   default = {
-    fully_qualified_domain_name     = ""
+    fully_qualified_domain_name     = null
     enable_alerts                   = false
     alert_threshold_milliseconds    = 1000
     alert_rolling_window_minutes    = 5
@@ -90,22 +90,23 @@ variable "default_endpoint_config" {
 
 locals {
   # Merge defaults here in case only some values passed via default_endpoint_config
-  baseline_endpoint_config = defaults(var.default_endpoint_config, {
-    fully_qualified_domain_name     = ""
-    enable_alerts                   = false
-    alert_threshold_milliseconds    = 1000
-    alert_rolling_window_minutes    = 5
-    alert_rolling_window_percentile = 99
-    alert_retest_window_minutes     = 0
-    alert_notification_channels     = []
-  })
+  baseline_endpoint_config = merge(
+    { alert_notification_channels = [] },
+    defaults(var.default_endpoint_config, {
+      enable_alerts                   = false
+      alert_threshold_milliseconds    = 1000
+      alert_rolling_window_minutes    = 5
+      alert_rolling_window_percentile = 99
+      alert_retest_window_minutes     = 0
+    })
+  )
 }
 
 variable "endpoints" {
   type = map(object({
     endpoint_regex = string
 
-    fully_qualified_domain_name     = optional(string)
+    fully_qualified_domain_name = optional(string)
 
     enable_alerts                   = optional(bool)
     alert_threshold_milliseconds    = optional(number)
@@ -140,7 +141,7 @@ variable "endpoints" {
     }
     ```
   EOT
-  default = {}
+  default     = {}
 }
 
 locals {

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -173,7 +173,7 @@ locals {
     for name, config in local.partially_merged_endpoints : name => merge(
       config,
       {
-        computed_regex = "https://${replace(config.fully_qualified_domain_name, ".", "\\.")}${config.endpoint_regex}"
+        computed_regex = "https://${replace(config.fully_qualified_domain_name, ".", "\\\\.")}${config.endpoint_regex}"
       }
     )
   }

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -78,6 +78,7 @@ variable "default_endpoint_config" {
   EOT
   # Note defaults here so it appears in documentation
   default = {
+    fully_qualified_domain_name     = null
     enable_alerts                   = false
     alert_threshold_milliseconds    = 1000
     alert_rolling_window_minutes    = 5

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -173,7 +173,7 @@ locals {
     for name, config in local.partially_merged_endpoints : name => merge(
       config,
       {
-        computed_regex = "https://${replace(config.fully_qualified_domain_name, ".", "\\\\.")}${config.endpoint_regex}"
+        computed_regex = "https://${replace(config.fully_qualified_domain_name, ".", "\\.")}${config.endpoint_regex}"
       }
     )
   }

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -91,6 +91,7 @@ variable "default_endpoint_config" {
 locals {
   # Merge defaults here in case only some values passed via default_endpoint_config
   baseline_endpoint_config = defaults(var.default_endpoint_config, {
+    fully_qualified_domain_name     = ""
     enable_alerts                   = false
     alert_threshold_milliseconds    = 1000
     alert_rolling_window_minutes    = 5

--- a/terraform-modules/stackdriver/latency-tracking/variables.tf
+++ b/terraform-modules/stackdriver/latency-tracking/variables.tf
@@ -105,6 +105,7 @@ locals {
 variable "endpoints" {
   type = map(object({
     endpoint_regex = string
+    request_method = optional(string)
 
     fully_qualified_domain_name = optional(string)
 
@@ -125,23 +126,8 @@ variable "endpoints" {
     cloud resources, and the value attributes set how to identify the endpoint and any overrides
     for the domain name, alert, or Revere alert label configuration.
 
-    For `endpoint_regex`, recall that the Regex must be escaped through Terraform if you're using complex sequences.
-
-    Usage example:
-
-    ```hcl
-    default_endpoint_config = {
-      fully_qualified_domain_name = "example.com"
-    }
-
-    endpoints = {
-      "status" = {
-        endpoint_regex               = "/status"
-        enable_alerts                = true
-        alert_threshold_milliseconds = 750
-      }
-    }
-    ```
+    - `endpoint_regex` should start with the leading "/", and remember that characters must be escaped through Terraform
+    - `request_method`, if provided, should be an all-caps HTTP method like "GET" or "POST" 
   EOT
   default     = {}
 }
@@ -155,6 +141,7 @@ locals {
   partially_merged_endpoints = var.enabled ? {
     for name, config in var.endpoints : name => {
       endpoint_regex = config.endpoint_regex
+      request_method = config.request_method
 
       fully_qualified_domain_name = coalesce(config.fully_qualified_domain_name, local.baseline_endpoint_config.fully_qualified_domain_name)
 


### PR DESCRIPTION
Documentation for this module is [here](https://github.com/broadinstitute/terraform-shared/blob/DDO-1582-latency-tracking/terraform-modules/stackdriver/latency-tracking/README.md)

Changes since Chelsea's approval:
- Added a test directory, with a usage example that works with `terraform validate`
- Added a github action to run the aforementioned `terraform validate`
- Included the usage example in the readme
- Added the ability to filter requests by method: "GET", "POST", etc
- Some JSON tweaks to the dashboard so that it matches that google's own API returns--so there's no diff ever


- The big one: discovered some race conditions where resources are unavailable for a split second _after terraform says they're created_. Because devs are going to be applying this Terraform a lot, and we can't really control the error message, I think the best route is to have Terraform actually pause between creating each type of resource. The way to do this is with, well, all the ugly toys: the null provider, depends_on, and local-exec provisioner with a sleep. The end result:

```
module.sam.module.latency_tracking.google_logging_metric.latency_metric["status"]: Creating...
module.sam.module.latency_tracking.google_logging_metric.latency_metric["status"]: Creation complete after 1s [id=sam-dev-status-endpoint-latency]
module.sam.module.latency_tracking.null_resource.pause_after_metric_change[0]: Creating...
module.sam.module.latency_tracking.null_resource.pause_after_metric_change[0]: Provisioning with 'local-exec'...
module.sam.module.latency_tracking.null_resource.pause_after_metric_change[0] (local-exec): Executing: ["/bin/sh" "-c" "sleep 3"]
module.sam.module.latency_tracking.null_resource.pause_after_metric_change[0]: Creation complete after 3s [id=2996187727450947607]
module.sam.module.latency_tracking.google_monitoring_alert_policy.latency_alert["status"]: Creating...
module.sam.module.latency_tracking.google_monitoring_alert_policy.latency_alert["status"]: Creation complete after 0s [id=projects/broad-dsde-dev/alertPolicies/18125449344785070202]
module.sam.module.latency_tracking.null_resource.pause_after_alert_change[0]: Creating...
module.sam.module.latency_tracking.null_resource.pause_after_alert_change[0]: Provisioning with 'local-exec'...
module.sam.module.latency_tracking.null_resource.pause_after_alert_change[0] (local-exec): Executing: ["/bin/sh" "-c" "sleep 3"]
module.sam.module.latency_tracking.null_resource.pause_after_alert_change[0]: Creation complete after 3s [id=6085930375933383859]
module.sam.module.latency_tracking.google_monitoring_dashboard.latency_dashboard[0]: Creating...
module.sam.module.latency_tracking.google_monitoring_dashboard.latency_dashboard[0]: Creation complete after 0s [id=projects/806222273987/dashboards/31afb2cf-0813-41bd-8295-916b2967b265]
```