### PR TITLE
DDO-1619 k8s-node-pool: Make it possible to use ssd boot disks

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -44,6 +44,7 @@ resource google_container_node_pool pool {
     image_type      = var.image_type
     machine_type    = var.machine_type
     disk_size_gb    = var.disk_size_gb
+    disk_type       = var.disk_type
     service_account = var.service_account
 
     # Protect node metadata

--- a/terraform-modules/k8s-node-pool/variables.tf
+++ b/terraform-modules/k8s-node-pool/variables.tf
@@ -53,6 +53,12 @@ variable disk_size_gb {
   description = "Size of disk to allocate for each node in the pool."
 }
 
+variable disk_type {
+  type        = string
+  description = "Type of disk to use for node boot disk. Can be pd-standard, pd-ssd, or pd-balanced"
+  default     = null
+}
+
 variable service_account {
   type        = string
   default     = null


### PR DESCRIPTION
Update k8s-node-pool to accept [disk type](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#disk_type) as a parameter.