### PR TITLE
[DDO-1720] Remove cloudsql-postgres replication_type

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -29,7 +29,6 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     activation_policy = var.cloudsql_activation_policy
     disk_autoresize   = var.cloudsql_disk_autoresize
     disk_type         = var.cloudsql_disk_type
-    replication_type  = var.cloudsql_replication_type
     tier              = var.cloudsql_tier
 
     backup_configuration {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -79,12 +79,6 @@ variable "cloudsql_activation_policy" {
   description = "The default activation policy for CloudSQL instances"
 }
 
-variable "cloudsql_replication_type" {
-  type        = string
-  default     = "SYNCHRONOUS"
-  description = "The default replication type for CloudSQL instances"
-}
-
 variable "cloudsql_insights_config" {
   type        = map
   default     = {}


### PR DESCRIPTION
Google removed this field when instances went from v1 to v2 ([old docs](https://registry.terraform.io/providers/hashicorp/google/3.52.0/docs/resources/sql_database_instance#settings.replication_type), absent from [new docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance)). @jacmrob hit an issue with this module still passing the variable [right here](https://github.com/broadinstitute/terraform-ap-deployments/pull/461#issuecomment-962225592), so I just tried to do the minimum thing and remove the now-invalid variable (committed to her module [here](https://github.com/broadinstitute/terraform-ap-modules/pull/208/commits/287a1bb98d722a253bebfad1f276a7960ab3dccf)). That seems to work based on the [plan](https://github.com/broadinstitute/terraform-ap-deployments/pull/461#issuecomment-963323775) so I think we merge/tag this and cross any future bridges when we get there.

I'll do a major version bump in the tag for this, since it is breaking within our own TF (not on remotes though, Google decommissioned the API where this field was supported in [2020](https://cloud.google.com/sql/docs/mysql/deprecation-notice))