### PR TITLE
fix deprecated syntax [AJ-133]

### DIFF
--- a/terraform-modules/google-project/api-services.tf
+++ b/terraform-modules/google-project/api-services.tf
@@ -3,6 +3,6 @@ module "enable-services" {
   providers = {
     google.target = google.target
   }
-  project     = "${google_project.project.name}"
+  project     = google_project.project.name
   services    = var.apis_to_enable
 }

--- a/terraform-modules/google-project/api-services.tf
+++ b/terraform-modules/google-project/api-services.tf
@@ -1,7 +1,7 @@
 module "enable-services" {
   source      = "github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services?ref=services-0.3.0-tf-0.12"
   providers = {
-    google.target = "google.target"
+    google.target = google.target
   }
   project     = "${google_project.project.name}"
   services    = var.apis_to_enable

--- a/terraform-modules/google-project/iam.tf
+++ b/terraform-modules/google-project/iam.tf
@@ -23,7 +23,7 @@ resource "google_project_iam_member" "roles-to-grant-by-email-and-type" {
   count = length(var.roles_to_grant_by_email_and_type)
   project     = google_project.project.name
   role    = var.roles_to_grant_by_email_and_type[count.index].role
-  member  = "${var.roles_to_grant_by_email_and_type[count.index].id_type == "" ? "serviceAccount" : var.roles_to_grant_by_email_and_type[count.index].id_type}:${var.roles_to_grant_by_email_and_type[count.index].email}"
+  member  = var.roles_to_grant_by_email_and_type[count.index].id_type == "" ? "serviceAccount" : var.roles_to_grant_by_email_and_type[count.index].id_type}:${var.roles_to_grant_by_email_and_type[count.index].email
 }
 
 resource "google_service_account_key" "service-accounts-with-keys" {
@@ -36,5 +36,5 @@ provider "vault" {}
 resource "vault_generic_secret" "app_account_key" {
   count = length(var.service_accounts_to_create_with_keys)
   path = var.service_accounts_to_create_with_keys[count.index].key_vault_path
-  data_json = "${base64decode(google_service_account_key.service-accounts-with-keys[count.index].private_key)}"
+  data_json = base64decode(google_service_account_key.service-accounts-with-keys[count.index].private_key)
 }

--- a/terraform-modules/google-project/iam.tf
+++ b/terraform-modules/google-project/iam.tf
@@ -23,7 +23,7 @@ resource "google_project_iam_member" "roles-to-grant-by-email-and-type" {
   count = length(var.roles_to_grant_by_email_and_type)
   project     = google_project.project.name
   role    = var.roles_to_grant_by_email_and_type[count.index].role
-  member  = var.roles_to_grant_by_email_and_type[count.index].id_type == "" ? "serviceAccount" : var.roles_to_grant_by_email_and_type[count.index].id_type}:${var.roles_to_grant_by_email_and_type[count.index].email
+  member  = "${var.roles_to_grant_by_email_and_type[count.index].id_type == "" ? "serviceAccount" : var.roles_to_grant_by_email_and_type[count.index].id_type}:${var.roles_to_grant_by_email_and_type[count.index].email}"
 }
 
 resource "google_service_account_key" "service-accounts-with-keys" {

--- a/terraform-modules/google-project/project.tf
+++ b/terraform-modules/google-project/project.tf
@@ -1,5 +1,5 @@
 resource "google_project" "project" {
-  provider = "google.target"
+  provider = google.target
   name                  = "${var.project_name}"
   project_id            = "${var.project_name}"
   billing_account       = "${var.billing_account_id}"

--- a/terraform-modules/google-project/project.tf
+++ b/terraform-modules/google-project/project.tf
@@ -1,8 +1,8 @@
 resource "google_project" "project" {
   provider = google.target
-  name                  = "${var.project_name}"
-  project_id            = "${var.project_name}"
-  billing_account       = "${var.billing_account_id}"
-  folder_id             = "${var.folder_id}"
+  name                  = var.project_name
+  project_id            = var.project_name
+  billing_account       = var.billing_account_id
+  folder_id             = var.folder_id
   auto_create_network   = false
 }


### PR DESCRIPTION
This PR has no functional changes, but updates syntax to remove deprecation warnings. As we set out to upgrade import-service's TF and implement some fixes to that TF, I really want to get rid of the deprecation warnings to make the upgrade path easier. See https://www.terraform.io/language/upgrade-guides/0-12#first-class-expressions as an example of deprecated syntax.

The updates in this PR are referenced from broadinstitute/import_service_terraform#19, which in turn is referenced from broadinstitute/terraform-ap-deployments#686. You can see the `atlantis plan` results in the latter PR.

Once this PR is approved and merged, I will create a release in this repo and then point the referencing PRs at the release instead of at this branch.