### PR TITLE
DDO-2502 Make SSL Validation Toggleable on Uptime Checkk

### DIFF
--- a/terraform-modules/stackdriver/uptime-check/uptime.tf
+++ b/terraform-modules/stackdriver/uptime-check/uptime.tf
@@ -9,7 +9,7 @@ resource "google_monitoring_uptime_check_config" "uptime_check" {
     path         = var.path
     port         = local.port
     use_ssl      = var.https_enabled
-    validate_ssl = var.https_enabled
+    validate_ssl = local.validate_ssl
   }
 
   monitored_resource {
@@ -19,4 +19,8 @@ resource "google_monitoring_uptime_check_config" "uptime_check" {
       host       = var.fqdn
     }
   }
+}
+
+local {
+  validate_ssl = var.validate_ssl == false ? validate_ssl : var.https_enabled
 }

--- a/terraform-modules/stackdriver/uptime-check/variables.tf
+++ b/terraform-modules/stackdriver/uptime-check/variables.tf
@@ -76,6 +76,12 @@ variable "https_enabled" {
   default     = true
 }
 
+variable "validate_ssl" {
+  type        = bool
+  description = "whether to perform ssl validation as part of uptime check"
+  default     = true
+}
+
 variable "resource_type" {
   type        = string
   description = "The GCP resource type that the uptime check will monitor. Defaults to checking a fqdn"


### PR DESCRIPTION
It seems that google uptime checks have a bug in their SSL validation where they sometimes don't trust certs from certain CAs even though the cert is valid. InCommon appears to be one of them. Making SSL validation toggleable on uptime checks created by this module.