### PR TITLE
Add a toggle for enforcing PSPs since they are now deprecated

### DIFF
--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -80,7 +80,7 @@ resource google_container_cluster cluster {
 
   # CIS compliance: Enable PodSecurityPolicyController
   pod_security_policy_config {
-    enabled = true
+    enabled = var.enforce_pod_security_policy
   }
 
   dynamic "workload_identity_config" {

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -122,3 +122,9 @@ variable istio_auth {
   default     = "AUTH_NONE"
   description = "Istio auth mode"
 }
+
+variable enforce_pod_security_policy {
+  type        = bool
+  default     = true
+  description = "whether to enable requirement for pods to have a pod security policy associated"
+}


### PR DESCRIPTION
Pod Security Policies are deprecated as of k8s 1.21, add a toggle to turn off the requirement for every pod to have an associated psp, still defaults to true as we don't want to accidentally turn this off in envs that care about CIS compliance.