### PR TITLE
Support for Google Provider 5.x

### DIFF
--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -50,14 +50,21 @@ resource google_container_node_pool pool {
     # Protect node metadata
     workload_metadata_config {
       # Workload Identity only works when using the metadata server.
-      node_metadata = var.enable_workload_identity ? "GKE_METADATA_SERVER" : "SECURE"
+    mode = var.enable_workload_identity ? "GKE_METADATA" : "MODE_UNSPECIFIED"
     }
 
     metadata = var.metadata
     labels   = var.labels
     tags     = var.tags
 
-    taint = var.taints
+    dynamic "taint" {
+      for_each = var.taints
+      content {
+        effect = taint.value.effect
+        key    = taint.value.key
+        value  = taint.value.value
+      }
+    }
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",

--- a/terraform-modules/k8s-node-pool/main.tf
+++ b/terraform-modules/k8s-node-pool/main.tf
@@ -50,7 +50,7 @@ resource google_container_node_pool pool {
     # Protect node metadata
     workload_metadata_config {
       # Workload Identity only works when using the metadata server.
-    mode = var.enable_workload_identity ? "GKE_METADATA" : "MODE_UNSPECIFIED"
+      mode = var.enable_workload_identity ? "GKE_METADATA" : "MODE_UNSPECIFIED"
     }
 
     metadata = var.metadata

--- a/terraform-modules/k8s-node-pool/versions.tf
+++ b/terraform-modules/k8s-node-pool/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 3.55.0"
+      version = ">= 5.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">= 3.55.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform-modules/k8s-node-pool/versions.tf
+++ b/terraform-modules/k8s-node-pool/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/terraform-modules/k8s-node-pool/versions.tf
+++ b/terraform-modules/k8s-node-pool/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 4.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">= 5.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
Enabling support for node pools created using the google providers of version 5.x.x and greater