### PR TITLE
[DDO-3879] Change query_insights_config variable type from map to object

### DIFF
--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -80,7 +80,12 @@ variable "cloudsql_activation_policy" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = object
+  type        = object({
+    query_insights_enabled  = bool,
+    query_string_length     = number,
+    record_application_tags = bool,
+    record_client_address   = bool,
+  })
   default     = {}
   description = "Config parameters for Query Insights"
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -80,7 +80,7 @@ variable "cloudsql_activation_policy" {
 }
 
 variable "cloudsql_insights_config" {
-  type        = map
+  type        = object
   default     = {}
   description = "Config parameters for Query Insights"
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,7 +86,12 @@ variable "cloudsql_insights_config" {
     record_application_tags = bool,
     record_client_address   = bool,
   })
-  default     = {}
+  default     = object({
+    query_insights_enabled  = false,
+    query_string_length     = null,
+    record_application_tags = null,
+    record_client_address   = null
+  })
   description = "Config parameters for Query Insights"
 }
 locals {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -86,12 +86,12 @@ variable "cloudsql_insights_config" {
     record_application_tags = bool,
     record_client_address   = bool,
   })
-  default     = object({
+  default     = {
     query_insights_enabled  = false,
     query_string_length     = null,
     record_application_tags = null,
     record_client_address   = null
-  })
+  }
   description = "Config parameters for Query Insights"
 }
 locals {


### PR DESCRIPTION
Convert cloudsql-postgres cloudsql_insights_config variable to an object instead of a map.

### Why
This fixes a type error that came up while @rjohanek and I were reviving the Jade / TDR Terraform in https://github.com/broadinstitute/terraform-ap-deployments/pull/1707
```

Error: Invalid value for module argument

  on modules/datarepo-app/cloudsql.tf line 5, in module "cloudsql":
   5:   cloudsql_insights_config =  {
   6:     query_insights_enabled  = true
   7:     query_string_length     = 1024
   8:     record_application_tags = false
   9:     record_client_address   = false
  10:   }

The given value is not suitable for child module variable
"cloudsql_insights_config" defined at
.terraform/modules/datarepo-app.cloudsql/terraform-modules/cloudsql-postgres/variables.tf:82,1-36:
all map elements must have the same type.
```