### PR TITLE
[DC-1234] add maintenance policy variable

### DIFF
--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -128,3 +128,21 @@ variable enforce_pod_security_policy {
   default     = true
   description = "whether to enable requirement for pods to have a pod security policy associated"
 }
+
+variable maintenance_policy {
+  type        = object({
+    recurring_window = object({
+      start_time = string,
+      end_time = string,
+      recurrence = string
+    })
+  })
+  description = "Maintenance policy for the cluster"
+  default     = {
+    recurring_window = {
+      start_time = null,
+      end_time = null,
+      recurrence = null
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add maintenance_policy variable to k8s-master

##Why
So it can be passed in for datarepo-jade terraform. This is needed so there can be different values for this attribute for staging compared to production. Using this variable in datarepo-jade will allow the resolution of this unwanted diff which came up during the process of reviving terraform for tdr.  https://github.com/broadinstitute/terraform-ap-deployments/pull/1707#issuecomment-2364267681

```# module.core-infrastructure.module.k8s-master.google_container_cluster.cluster will be updated in-place
~ resource "google_container_cluster" "cluster" {
        id                          = "projects/terra-datarepo-production/locations/us-central1/clusters/jade-master-us-central1"
        name                        = "jade-master-us-central1"
      + remove_default_node_pool    = true
        # (26 unchanged attributes hidden)
      - maintenance_policy {
          - recurring_window {
              - end_time   = "2024-03-12T12:00:00Z" -> null
              - recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" -> null
              - start_time = "2024-03-12T06:00:00Z" -> null
            }
        }
        # (20 unchanged blocks hidden)
    }

