### PR TITLE
[DC-1234] Add maintenance policy variable

### DIFF
--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -23,7 +23,13 @@ resource google_container_cluster cluster {
 
   min_master_version = data.google_container_engine_versions.cluster_versions.latest_master_version
 
-  maintenance_policy = var.maintenance_policy
+  maintenance_policy {
+    recurring_window {
+      end_time   = var.maintenance_policy.recurring_window.end_time
+      recurrence = var.maintenance_policy.recurring_window.recurrence
+      start_time = var.maintenance_policy.recurring_window.start_time
+    }
+  }
 
   release_channel {
     channel = var.release_channel

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -23,6 +23,8 @@ resource google_container_cluster cluster {
 
   min_master_version = data.google_container_engine_versions.cluster_versions.latest_master_version
 
+  maintenance_policy = var.maintenance_policy
+
   release_channel {
     channel = var.release_channel
   }

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -23,11 +23,14 @@ resource google_container_cluster cluster {
 
   min_master_version = data.google_container_engine_versions.cluster_versions.latest_master_version
 
-  maintenance_policy {
-    recurring_window {
-      end_time   = var.maintenance_policy.recurring_window.end_time
-      recurrence = var.maintenance_policy.recurring_window.recurrence
-      start_time = var.maintenance_policy.recurring_window.start_time
+  dynamic "maintenance_policy" {
+    for_each = var.maintenance_policy.enabled ? [1] : []
+    content {
+      recurring_window {
+        start_time = var.maintenance_policy.recurring_window.start_time
+        end_time   = var.maintenance_policy.recurring_window.end_time
+        recurrence = var.maintenance_policy.recurring_window.recurrence
+      }
     }
   }
 

--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -27,9 +27,9 @@ resource google_container_cluster cluster {
     for_each = var.maintenance_policy.enabled ? [1] : []
     content {
       recurring_window {
-        start_time = var.maintenance_policy.recurring_window.start_time
-        end_time   = var.maintenance_policy.recurring_window.end_time
-        recurrence = var.maintenance_policy.recurring_window.recurrence
+        start_time = var.maintenance_policy.start_time
+        end_time   = var.maintenance_policy.end_time
+        recurrence = var.maintenance_policy.recurrence
       }
     }
   }

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -132,16 +132,18 @@ variable enforce_pod_security_policy {
 variable maintenance_policy {
   type        = object({
     recurring_window = object({
+      enabled    = bool
       start_time = string,
-      end_time = string,
+      end_time   = string,
       recurrence = string
     })
   })
   description = "Maintenance policy for the cluster"
   default     = {
     recurring_window = {
+      enabled    = false,
       start_time = null,
-      end_time = null,
+      end_time   = null,
       recurrence = null
     }
   }

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -128,3 +128,21 @@ variable enforce_pod_security_policy {
   default     = true
   description = "whether to enable requirement for pods to have a pod security policy associated"
 }
+
+variable maintenance_policy {
+  type        = object({
+    recurring_window = object({
+      start_time = string,
+      end_time = string,
+      recurrence = string
+    })
+  })
+  description = "Maintenance policy for the cluster"
+  default     = {
+    recurring_window = {
+      start_time = null,
+      end_time = null,
+      recurrence = null
+    }
+  }
+}

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -131,20 +131,16 @@ variable enforce_pod_security_policy {
 
 variable maintenance_policy {
   type        = object({
-    recurring_window = object({
-      enabled    = bool
-      start_time = string,
-      end_time   = string,
-      recurrence = string
-    })
+    enabled    = bool
+    start_time = string,
+    end_time   = string,
+    recurrence = string
   })
-  description = "Maintenance policy for the cluster"
+  description = "Recurring window maintenance policy for the cluster"
   default     = {
-    recurring_window = {
-      enabled    = false,
-      start_time = null,
-      end_time   = null,
-      recurrence = null
-    }
+    enabled    = false,
+    start_time = null,
+    end_time   = null,
+    recurrence = null
   }
 }


### PR DESCRIPTION
## Summary
Add maintenance_policy variable to k8s-master

## Why
So it can be passed in for datarepo-jade terraform. This is needed so there can be different values for this attribute for staging compared to production. Using this variable in datarepo-jade will allow the resolution of this unwanted diff which came up during the process of reviving terraform for tdr. https://github.com/broadinstitute/terraform-ap-deployments/pull/1707#issuecomment-2364267681

```  
# module.core-infrastructure.module.k8s-master.google_container_cluster.cluster will be updated in-place
 ~ resource "google_container_cluster" "cluster" {
        id                          = "projects/terra-datarepo-production/locations/us-central1/clusters/jade-master-us-central1"
        name                        = "jade-master-us-central1"
      + remove_default_node_pool    = true
        # (26 unchanged attributes hidden)
      - maintenance_policy {
          - recurring_window {
              - end_time   = "2024-03-12T12:00:00Z" -> null
              - recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" -> null
              - start_time = "2024-03-12T06:00:00Z" -> null
            }
        }
        # (20 unchanged blocks hidden)
    }