### PR TITLE
[DC-1234] Add cloudsql backup location

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -35,6 +35,7 @@ resource "google_sql_database_instance" "cloudsql_instance" {
       binary_log_enabled = false
       enabled            = true
       start_time         = "06:00"
+      location           = var.cloudsql_backup_location
       backup_retention_settings {
         retained_backups = var.cloudsql_retained_backups
       }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -201,6 +201,12 @@ variable "cloudsql_retained_backups" {
   description = "Number of days to retain backups"
 }
 
+variable "cloudsql_backup_location" {
+  type        = string
+  default     = "us"
+  description = "Location for backups"
+}
+
 locals {
   private_network = var.enable_private_services ? var.private_network_self_link : var.existing_vpc_network
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -203,7 +203,7 @@ variable "cloudsql_retained_backups" {
 
 variable "cloudsql_backup_location" {
   type        = string
-  default     = "us"
+  default     = null
   description = "Location for backups"
 }
 


### PR DESCRIPTION
## Summary
Add cloudsql_backup_location variable to cloudsql-postgres

## Why
So the default value us can be used in datarepo-jade terraform for production. This is needed so there can be different values for this attribute for staging (null) compared to production ("us"). Adding this variable w this default value will allow the resolution of this unwanted diff which came up during the process of reviving terraform for tdr. 
https://github.com/broadinstitute/terraform-ap-deployments/pull/1707#issuecomment-2368744334 
```
  # module.datarepo-app.module.cloudsql.google_sql_database_instance.cloudsql_instance[0] will be updated in-place
~ resource "google_sql_database_instance" "cloudsql_instance" {
        id                            = "datarepo-db-jade-194e97f22b7667c6"
        name                          = "datarepo-db-jade-194e97f22b7667c6"
        # (11 unchanged attributes hidden)

      ~ settings {
            # (13 unchanged attributes hidden)

          ~ backup_configuration {
              - location                       = "us" -> null
                # (5 unchanged attributes hidden)

                # (1 unchanged block hidden)
            }
