### PR TITLE
[DDO-3879] Fix typo in k8s-cluster-monitoring

### DIFF
--- a/terraform-modules/stackdriver/k8s-cluster-monitoring/variables.tf
+++ b/terraform-modules/stackdriver/k8s-cluster-monitoring/variables.tf
@@ -55,7 +55,7 @@ variable "group_by_labels" {
   default = {
     node_name             = "resource.labels.node_name"
     node_health_condition = "metric.label.condition"
-    cluster_name          = "resource.labels.cluster_name"
+    cluster_name          = "resource.label.cluster_name"
     namespace_name        = "resource.label.namespace_name"
     deployment            = "metric.label.deployment"
     pod_name              = "resource.label.pod_name"


### PR DESCRIPTION
This line seems to be causing a spurious diff in the Jade terraform.