### PR TITLE
DC-1273: Remove deprecated attributes

### DIFF
--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -64,16 +64,12 @@ resource google_container_cluster cluster {
 
   # CIS compliance: disable legacy Auth
   enable_legacy_abac = false
-
-  # CIS compliance: disable basic auth -- this creates a certificate and
-  # disables basic auth by not specifying a user / pasword.
-  # See https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth
+  
+  # https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth
   master_auth {
     client_certificate_config {
       issue_client_certificate = true
     }
-    username = ""
-    password = ""
   }
 
   # CIS compliance: Enable Network Policy


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-1273

______

From the code comments, we originally needed to set username and password to an empty string to disable basic authentication. 

According to the following output from an [atlantis plan in terraform-ap-deployments](https://github.com/broadinstitute/terraform-ap-deployments/pull/1719#issuecomment-2379922218), basic authentication was removed for GKE cluster versions >= 1.19. Data Repo, DSDE and zebrafish appear to met this version requirement. So, we no longer need to set these fields to empty. 

```
Warning: Deprecated Attribute

  on .terraform/modules/core-infrastructure.k8s-master/terraform-modules/k8s-master/main.tf line 75, in resource "google_container_cluster" "cluster":
  75:     username = ""

Basic authentication was removed for GKE cluster versions >= 1.19. If
master_auth is present in your config with only password or username set, you
can remove the block entirely.
```