### PR TITLE
Adding support for GCE instance resource policies (SCP-5918)

### DIFF
--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -78,7 +78,7 @@ resource "google_compute_instance" "instance" {
   }
 
   # instance resource policies
-  resource_policies = var.enable_resource_policy == "1" ? [ google_compute_resource_policy.resource-policy.self_link ] : null
+  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy.self_link ] : null
 
   lifecycle {
     prevent_destroy = false

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -29,10 +29,11 @@ data "google_compute_subnetwork" "instance-subnetwork" {
 
 # instance resource policy for adding start/stop schedule
 resource "google_compute_resource_policy" "resource-policy" {
+  count    = var.enable_resource_policy ? 1 : 0
   provider = google.target
-  project = var.project
-  region = var.instance_region
-  name = "${var.instance_name}-resource-policy"
+  project  = var.project
+  region   = var.instance_region
+  name     = "${var.instance_name}-resource-policy"
 
   instance_schedule_policy {
     vm_start_schedule {
@@ -81,7 +82,7 @@ resource "google_compute_instance" "instance" {
   }
 
   # instance resource policies
-  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy.self_link ] : null
+  resource_policies = var.enable_resource_policy ? [ google_compute_resource_policy.resource-policy[0].self_link ] : null
 
   lifecycle {
     prevent_destroy = false

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -33,7 +33,6 @@ resource "google_compute_resource_policy" "resource-policy" {
   project = var.project
   region = var.instance_region
   name = "${var.instance_name}-resource-policy"
-  count = var.enable_resource_policy? 1 : 0
 
   instance_schedule_policy {
     vm_start_schedule {
@@ -82,7 +81,7 @@ resource "google_compute_instance" "instance" {
   }
 
   # instance resource policies
-  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy[count.index].self_link ] : null
+  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy.self_link ] : null
 
   lifecycle {
     prevent_destroy = false

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -33,7 +33,7 @@ resource "google_compute_resource_policy" "resource-policy" {
   project = var.project
   region = var.instance_region
   name = "${var.instance_name}-resource-policy"
-  count = var.enable_resource_policy == "1" ? 1 : 0
+  count = var.enable_resource_policy? 1 : 0
 
   instance_schedule_policy {
     vm_start_schedule = var.instance_schedule_vm_start

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -36,8 +36,12 @@ resource "google_compute_resource_policy" "resource-policy" {
   count = var.enable_resource_policy? 1 : 0
 
   instance_schedule_policy {
-    vm_start_schedule = var.instance_schedule_vm_start
-    vm_stop_schedule = var.instance_schedule_vm_stop
+    vm_start_schedule {
+      schedule = var.instance_schedule_vm_start
+    }
+    vm_stop_schedule {
+      schedule = var.instance_schedule_vm_stop
+    }
     time_zone = var.instance_schedule_time_zone
   }
 }

--- a/terraform-modules/docker-instance-data-disk/instance.tf
+++ b/terraform-modules/docker-instance-data-disk/instance.tf
@@ -82,7 +82,7 @@ resource "google_compute_instance" "instance" {
   }
 
   # instance resource policies
-  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy.self_link ] : null
+  resource_policies = var.enable_resource_policy? [ google_compute_resource_policy.resource-policy[count.index].self_link ] : null
 
   lifecycle {
     prevent_destroy = false

--- a/terraform-modules/docker-instance-data-disk/variables.tf
+++ b/terraform-modules/docker-instance-data-disk/variables.tf
@@ -94,10 +94,10 @@ variable "instance_scopes" {
   type    = list(string)
   description = "The default scopes for instance"
   default = [
-    "userinfo-email", 
-    "compute-ro", 
-    "storage-ro", 
-    "https://www.googleapis.com/auth/monitoring.write", 
+    "userinfo-email",
+    "compute-ro",
+    "storage-ro",
+    "https://www.googleapis.com/auth/monitoring.write",
     "logging-write" ]
 }
 
@@ -138,4 +138,24 @@ variable "instance_data_disk_type" {
 variable "instance_data_disk_name" {
   default = "data"
   description = "default disk type for docker volume"
+}
+
+# control adding resource policy to instances
+variable "enable_resource_policy" {
+  default = "0"
+}
+
+variable "instance_schedule_vm_start" {
+  description = "Cron schedule for starting GCE instances using policy; default 9AM daily"
+  default = "0 9 * * *"
+}
+
+variable "instance_schedule_vm_stop" {
+  description = "Cron schedule for stopping GCE instances using policy; default 5PM daily"
+  default = "0 17 * * *"
+}
+
+variable "instance_schedule_time_zone" {
+  description = "Timezone for GCE instance schedule policies"
+  default = "US/Central"
 }

--- a/terraform-modules/docker-instance-data-disk/variables.tf
+++ b/terraform-modules/docker-instance-data-disk/variables.tf
@@ -140,9 +140,11 @@ variable "instance_data_disk_name" {
   description = "default disk type for docker volume"
 }
 
-# control adding resource policy to instances
+# control adding resource policy to GCE instances
+# sets instance schedules to start/stop VMs automatically via cron schedule
+# see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#example-usage---resource-policy-instance-schedule-policy
 variable "enable_resource_policy" {
-  default = "0"
+  default = false
 }
 
 variable "instance_schedule_vm_start" {


### PR DESCRIPTION
This update adds support for a `google_compute_resource_policy` to be attached to a GCE instance via the `docker-instance-data-disk` module.  Currently this only supports specifying an instance schedule policy, but other policies could be added via the [Terraform module](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy).  This is controlled via a new flag called `enable_resource_policy` which is turned off by default.