### PR TITLE
Updating docker-instance-data-disk startup script to work on CentOS Stream 9 (SCP-5965)

### DIFF
--- a/terraform-modules/docker-instance-data-disk/centos-ansible.sh
+++ b/terraform-modules/docker-instance-data-disk/centos-ansible.sh
@@ -18,7 +18,7 @@ source /root/.bashrc
 
 #install pip and ansible
 yum install epel-release -y
-yum update
+yum update -y
 yum install python3.12 python3.12-pip git jq python-setuptools -y
 python3.12 -m pip install --upgrade pip
 python3.12 -m pip install virtualenv
@@ -45,13 +45,10 @@ ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
 # manually install Docker since ansible will only run on python3.6
 dnf -y install dnf-plugins-core
-dnf update
+dnf -y update
 dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 dnf -y install docker-ce docker-ce-cli containerd.io
 systemctl enable --now docker
-
-touch /etc/sysconfig/gce-metadata-run
-chmod 0644 /etc/sysconfig/gce-metadata-run
 
 # add users to Docker group
 useradd jenkins
@@ -61,3 +58,9 @@ usermod -aG docker jenkins
 
 # Prevent dnf from arbitrarily updating docker packages
 echo "exclude=docker*,containerd.io" >> /etc/dnf/dnf.conf
+
+# confirm docker works
+docker run hello-world
+
+touch /etc/sysconfig/gce-metadata-run
+chmod 0644 /etc/sysconfig/gce-metadata-run

--- a/terraform-modules/docker-instance-data-disk/centos-ansible.sh
+++ b/terraform-modules/docker-instance-data-disk/centos-ansible.sh
@@ -6,55 +6,44 @@ if [ -f /etc/sysconfig/gce-metadata-run ];
     exit 0
 fi
 
+# exit on error
+set -e
+
 #stop and disable firewalld
-systemctl stop firewalld.service
-systemctl disable firewalld.service
+systemctl disable --now firewalld
 
 # update path so pip/virtualenv are available
-export PATH=/usr/local/bin:$PATH
-echo "export PATH=/usr/local/bin:$PATH" >> /root/.bashrc
+echo "export PATH=/usr/local/bin:${PATH}" >> /root/.bashrc
+source /root/.bashrc
 
 #install pip and ansible
 yum install epel-release -y
 yum update
 yum install python3.12 python3.12-pip git jq python-setuptools -y
-python3.12 -m pip install --upgrade pip
-python3.12 -m pip install virtualenv
+python3.12 -m pip install --upgrade pip virtualenv -y
 virtualenv /usr/local/bin/ansible
 source /usr/local/bin/ansible/bin/activate
-python3.12 -m pip install ansible==2.7.8
-python3.12 -m pip install hvac
-python3.12 -m pip install ansible_merge_vars
+python3.12 -m pip install hvac ansible_merge_vars ansible==2.7.8 -y
 
 # convert labels to env vars
 gcloud compute instances list --filter="name:$(hostname)" --format 'value(labels)' | tr ';' '\n' | while read var ; do key="${var%=*}"; value="${var##*=}" ; key=$(echo $key | tr '[a-z]' '[A-Z]') ; echo "export $key=\"$value\"" ; done  > /etc/bashrc-labels
-
-# gcloud compute instances list --filter="name:$(hostname)" --format=json | jq .[].labels | tr -d '"|,|{|}|:' | while read key value ; do if [ ! -z "${key}" ] ; then  key=$(echo $key | tr '[a-z]' '[A-Z]') ; echo "export $key=\"$value\"" ; fi ; done > /etc/bashrc-labels
 
 echo "test -f /etc/bashrc-labels && source /etc/bashrc-labels" >> /etc/bashrc
 source /etc/bashrc-labels
 
 #env vars and paths
 echo "source /usr/local/bin/ansible/bin/activate " >> /root/.bashrc
-# echo "export GPROJECT=${gproject_ansible}"  >> /root/.bashrc
-# echo "export ANSIBLE_BRANCH=${ansible_branch}"  >> /root/.bashrc
 source /root/.bashrc
 
 #needed for checkout otherwise ssh cannot git clone or checkout
-mkdir ~/.ssh
+mkdir -p ~/.ssh
 ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-
-# Fetch all the common setup scripts from GCE metadata
-#curl -sH 'Metadata-Flavor: Google' http://metadata/computeMetadata/v1/project/attributes/ansible-key > /root/.ssh/id_rsa
-#chmod 0600 /root/.ssh/id_rsa
 
 #find newly added disks without rebooting ie:scratch disks
 /usr/bin/rescan-scsi-bus.sh
 
 #one time anisble run
 ansible-pull provisioner.yml -C ${ANSIBLE_BRANCH} -d /var/lib/ansible/local -U https://github.com/broadinstitute/dsp-ansible-configs.git -i hosts >> /root/ansible-provisioner-firstrun.log 2>&1
-
-# sh /root/ansible-setup.sh 2>&1 | tee /root/ansible-setup.log
 
 # manually install Docker since ansible will only run on python3.6
 dnf -y install dnf-plugins-core

--- a/terraform-modules/docker-instance-data-disk/centos-ansible.sh
+++ b/terraform-modules/docker-instance-data-disk/centos-ansible.sh
@@ -20,10 +20,11 @@ source /root/.bashrc
 yum install epel-release -y
 yum update
 yum install python3.12 python3.12-pip git jq python-setuptools -y
-python3.12 -m pip install --upgrade pip virtualenv -y
+python3.12 -m pip install --upgrade pip
+python3.12 -m pip install virtualenv
 virtualenv /usr/local/bin/ansible
 source /usr/local/bin/ansible/bin/activate
-python3.12 -m pip install hvac ansible_merge_vars ansible==2.7.8 -y
+python3.12 -m pip install hvac ansible_merge_vars ansible==2.7.8
 
 # convert labels to env vars
 gcloud compute instances list --filter="name:$(hostname)" --format 'value(labels)' | tr ';' '\n' | while read var ; do key="${var%=*}"; value="${var##*=}" ; key=$(echo $key | tr '[a-z]' '[A-Z]') ; echo "export $key=\"$value\"" ; done  > /etc/bashrc-labels
@@ -41,9 +42,6 @@ ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
 #find newly added disks without rebooting ie:scratch disks
 /usr/bin/rescan-scsi-bus.sh
-
-#one time anisble run
-ansible-pull provisioner.yml -C ${ANSIBLE_BRANCH} -d /var/lib/ansible/local -U https://github.com/broadinstitute/dsp-ansible-configs.git -i hosts >> /root/ansible-provisioner-firstrun.log 2>&1
 
 # manually install Docker since ansible will only run on python3.6
 dnf -y install dnf-plugins-core


### PR DESCRIPTION
#### BACKGROUND & CHANGES
This updates the `centos-ansible.sh` startup script for the `docker-instance-data-disk` module to work on CentOS Stream 9.  Notable changes are updating to Python 3.12 and manual installation of Docker CE as the ansible automation is hard-coded to Python 3.6 and doesn't work anymore.

#### MANUAL TESTS
[This instance](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/instance-20250402-154102?invt=Abtr1Q&project=broad-singlecellportal-bistlin) was manually provisioned with CentOS Stream 9 and the startup script added as custom metadata.  The script ran successfully and all necessary packages were installed.  This can be verified by:
* Restart VM if stopped
* SSH into VM instance
```
gcloud compute ssh instance-20250402-154102 --project broad-singlecellportal-bistlin --tunnel-through-iap
```
* Run `sudo -i`
* Check Python: 
```
$ which python3
/usr/local/bin/ansible/bin/python3

$ python3 --version
Python 3.12.9
```
* Check Docker:
```
$ which docker
/usr/bin/docker

$ docker run hello-world
Unable to find image 'hello-world:latest' locally
latest: Pulling from library/hello-world
e6590344b1a5: Pull complete 
Digest: sha256:7e1a4e2d11e2ac7a8c3f768d4166c2defeb09d2a750b010412b6ea13de1efb19
Status: Downloaded newer image for hello-world:latest

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (amd64)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/
```