### PR TITLE
[DDO-4204] Support for both public and private IPs at the same time

### DIFF
--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -55,6 +55,7 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     ip_configuration {
       ipv4_enabled    = (var.private_enable && !var.private_enable_public_ip) ? false : true
       private_network = var.private_enable == true ? local.private_network : null
+      enable_private_path_for_google_cloud_services = var.private_enable ? true : null
       require_ssl     = true
       dynamic "authorized_networks" {
         for_each = var.cloudsql_authorized_networks

--- a/terraform-modules/cloudsql-postgres/cloudsql.tf
+++ b/terraform-modules/cloudsql-postgres/cloudsql.tf
@@ -53,7 +53,7 @@ resource "google_sql_database_instance" "cloudsql_instance" {
     }
 
     ip_configuration {
-      ipv4_enabled    = var.private_enable == true ? false : true
+      ipv4_enabled    = (var.private_enable && !var.private_enable_public_ip) ? false : true
       private_network = var.private_enable == true ? local.private_network : null
       require_ssl     = true
       dynamic "authorized_networks" {

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -219,5 +219,5 @@ data "google_compute_network" "existing_vpc_network" {
 }
 
 locals {
-  private_network = var.enable_private_services ? var.private_network_self_link : var.existing_vpc_network[0].self_link
+  private_network = var.enable_private_services ? var.private_network_self_link : data.google_compute_network.existing_vpc_network[0].self_link
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -213,6 +213,11 @@ variable "cloudsql_deletion_protection_enabled" {
   description = "Whether to enable deletion protection"
 }
 
+data "google_compute_network" "existing_vpc_network" {
+  count = var.private_enable && var.existing_vpc_network != null ? 1 : 0
+  name  = var.existing_vpc_network
+}
+
 locals {
-  private_network = var.enable_private_services ? var.private_network_self_link : var.existing_vpc_network
+  private_network = var.enable_private_services ? var.private_network_self_link : var.existing_vpc_network[0].self_link
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -219,5 +219,5 @@ data "google_compute_network" "existing_vpc_network" {
 }
 
 locals {
-  private_network = var.enable_private_services ? var.private_network_self_link : data.google_compute_network.existing_vpc_network[0].self_link
+  private_network = var.private_enable ? (var.enable_private_services ? var.private_network_self_link : data.google_compute_network.existing_vpc_network[0].self_link) : null
 }

--- a/terraform-modules/cloudsql-postgres/variables.tf
+++ b/terraform-modules/cloudsql-postgres/variables.tf
@@ -177,6 +177,12 @@ variable "private_enable" {
   default     = false
 }
 
+variable "private_enable_public_ip" {
+  type        = bool
+  description = "If true, enable private AND public IPs for the CloudSQL instance"
+  default     = false
+}
+
 variable "enable_private_services" {
   type        = bool
   description = "Enable flag for a private sql instance if set to true, a private sql isntance will be created."


### PR DESCRIPTION
Make it possible to set both private and public IPs on a CloudSQL instance at the same time.