### PR TITLE
[DC-1498] Disable High Availability for terra-datarepo-production CloudSQL database

### DIFF
--- a/terraform-modules/k8s-master/main.tf
+++ b/terraform-modules/k8s-master/main.tf
@@ -131,4 +131,6 @@ resource google_container_cluster cluster {
       auth     = var.istio_auth
     }
   }
+
+  availability_type = var.availability_type
 }

--- a/terraform-modules/k8s-master/variables.tf
+++ b/terraform-modules/k8s-master/variables.tf
@@ -144,3 +144,9 @@ variable maintenance_policy {
     recurrence = null
   }
 }
+
+variable availability_type {
+  type = string
+  default = "ZONAL"
+  description = "Sets availability type"
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DC-1498

This change is necessary to unblock this PR:  https://github.com/broadinstitute/terraform-ap-deployments/pull/1985
See the comment: https://github.com/broadinstitute/terraform-ap-deployments/pull/1985#issuecomment-3358091621

Since the availability type variable is not supported we need to add it here so it can be used in that PR. 
